### PR TITLE
Fix spurious eviction in FIFO caches when updating an existing key

### DIFF
--- a/lib/src/caches/ephemeral_fifo_cache.dart
+++ b/lib/src/caches/ephemeral_fifo_cache.dart
@@ -65,7 +65,7 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
-      if (_cache.length >= maxSize) {
+      if (!_cache.containsKey(key) && _cache.length >= maxSize) {
         _cache.remove(
           _cache.keys.first,
         ); // Remove the oldest element following FIFO

--- a/lib/src/caches/fifo_cache.dart
+++ b/lib/src/caches/fifo_cache.dart
@@ -59,7 +59,7 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
-      if (_cache.length >= maxSize) {
+      if (!_cache.containsKey(key) && _cache.length >= maxSize) {
         _cache.remove(
           _cache.keys.first,
         ); // Remove the oldest element following FIFO

--- a/lib/src/caches/simple_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/simple_ephemeral_fifo_cache.dart
@@ -54,7 +54,7 @@ class SimpleEphemeralFIFOCache<K, V> extends SimpleCache<K, V> {
   /// **This method is not thread-safe.**
   @override
   void set(K key, V value) {
-    if (_cache.length >= maxSize) {
+    if (!_cache.containsKey(key) && _cache.length >= maxSize) {
       _cache.remove(
         _cache.keys.first,
       ); // Remove the oldest element following FIFO

--- a/lib/src/caches/simple_fifo_cache.dart
+++ b/lib/src/caches/simple_fifo_cache.dart
@@ -53,7 +53,7 @@ class SimpleFIFOCache<K, V> extends SimpleCache<K, V> {
   /// **This method is not thread-safe.**
   @override
   void set(K key, V value) {
-    if (_cache.length >= maxSize) {
+    if (!_cache.containsKey(key) && _cache.length >= maxSize) {
       _cache.remove(
         _cache.keys.first,
       ); // Remove the oldest element following FIFO

--- a/test/caches/ephemeral_fifo_cache_test.dart
+++ b/test/caches/ephemeral_fifo_cache_test.dart
@@ -58,17 +58,33 @@ void main() {
       await cache.set(
         'key1',
         'new_value1',
-      ); // key1 is placed at the most recent position
+      ); // key1's value is updated; its FIFO position does not change
 
       await cache.set(
         'key3',
         'value3',
-      ); // The oldest key, key2, should be evicted
+      ); // key1, being the oldest, should be evicted
 
-      expect(await cache.get('key2'), isNull); // key2 should be removed
-      expect(await cache.get('key1'), equals('new_value1'));
+      expect(await cache.get('key1'), isNull); // key1 should be removed (oldest)
+      expect(await cache.get('key2'), equals('value2')); // key2 should remain
       expect(await cache.get('key3'), equals('value3'));
     });
+
+    test(
+      'Updating an existing key at capacity does not evict any entry',
+      () async {
+        final cache = EphemeralFIFOCache<String, String>(3);
+        await cache.set('A', 'valueA');
+        await cache.set('B', 'valueB');
+        await cache.set('C', 'valueC');
+
+        await cache.set('B', 'newValueB'); // update existing key — no eviction
+
+        expect(cache.getKeys().length, equals(3));
+        expect(cache.getKeys(), containsAll(['A', 'B', 'C']));
+        expect(await cache.get('B'), equals('newValueB'));
+      },
+    );
   });
 
   group('EphemeralFIFOCache - Thread-safety Tests', () {

--- a/test/caches/fifo_cache_test.dart
+++ b/test/caches/fifo_cache_test.dart
@@ -77,14 +77,27 @@ void main() {
         await cache.set('key2', 'value2');
         await cache.set('key1', 'new_value1'); // Order does not change
 
-        await cache.set('key3', 'value3'); // key2 will be evicted (FIFO order)
+        await cache.set('key3', 'value3'); // key1 will be evicted (FIFO order, key1 is oldest)
 
-        expect(await cache.get('key2'), isNull); // key2 should be removed
-        expect(
-          await cache.get('key1'),
-          equals('new_value1'),
-        ); // key1 should remain with new value
+        expect(await cache.get('key1'), isNull); // key1 should be removed (oldest)
+        expect(await cache.get('key2'), equals('value2')); // key2 should remain
         expect(await cache.get('key3'), equals('value3')); // key3 should be set
+      },
+    );
+
+    test(
+      'Updating an existing key at capacity does not evict any entry',
+      () async {
+        final cache = FIFOCache<String, String>(3);
+        await cache.set('A', 'valueA');
+        await cache.set('B', 'valueB');
+        await cache.set('C', 'valueC');
+
+        await cache.set('B', 'newValueB'); // update existing key — no eviction
+
+        expect(cache.getKeys().length, equals(3));
+        expect(cache.getKeys(), containsAll(['A', 'B', 'C']));
+        expect(await cache.get('B'), equals('newValueB'));
       },
     );
   });

--- a/test/caches/simple_ephemeral_fifo_cache_test.dart
+++ b/test/caches/simple_ephemeral_fifo_cache_test.dart
@@ -53,15 +53,28 @@ void main() {
         cache.set(
           'key1',
           'new_value1',
-        ); // key1 is placed at the newest position
+        ); // key1's value is updated; its FIFO position does not change
 
-        cache.set('key3', 'value3'); // key2, being the oldest, is evicted
+        cache.set('key3', 'value3'); // key1, being the oldest, is evicted
 
-        expect(cache.get('key2'), isNull); // key2 should be evicted
-        expect(cache.get('key1'), equals('new_value1'));
+        expect(cache.get('key1'), isNull); // key1 should be evicted (oldest)
+        expect(cache.get('key2'), equals('value2')); // key2 should remain
         expect(cache.get('key3'), equals('value3'));
       },
     );
+
+    test('Updating an existing key at capacity does not evict any entry', () {
+      final cache = SimpleEphemeralFIFOCache<String, String>(3);
+      cache.set('A', 'valueA');
+      cache.set('B', 'valueB');
+      cache.set('C', 'valueC');
+
+      cache.set('B', 'newValueB'); // update existing key — no eviction
+
+      expect(cache.getKeys().length, equals(3));
+      expect(cache.getKeys(), containsAll(['A', 'B', 'C']));
+      expect(cache.get('B'), equals('newValueB'));
+    });
   });
 
   group('SimpleEphemeralFIFOCache - Get and Remove on Retrieval Tests', () {

--- a/test/caches/simple_fifo_cache_test.dart
+++ b/test/caches/simple_fifo_cache_test.dart
@@ -53,18 +53,31 @@ void main() {
         cache.set(
           'key1',
           'new_value1',
-        ); // key1 is placed at the newest position
+        ); // key1's value is updated; its FIFO position does not change
 
         cache.set(
           'key3',
           'value3',
-        ); // key2, being the oldest, should be evicted
+        ); // key1, being the oldest, should be evicted
 
-        expect(cache.get('key2'), isNull); // key2 should be evicted
-        expect(cache.get('key1'), equals('new_value1'));
+        expect(cache.get('key1'), isNull); // key1 should be evicted (oldest)
+        expect(cache.get('key2'), equals('value2')); // key2 should remain
         expect(cache.get('key3'), equals('value3'));
       },
     );
+
+    test('Updating an existing key at capacity does not evict any entry', () {
+      final cache = SimpleFIFOCache<String, String>(3);
+      cache.set('A', 'valueA');
+      cache.set('B', 'valueB');
+      cache.set('C', 'valueC');
+
+      cache.set('B', 'newValueB'); // update existing key — no eviction
+
+      expect(cache.getKeys().length, equals(3));
+      expect(cache.getKeys(), containsAll(['A', 'B', 'C']));
+      expect(cache.get('B'), equals('newValueB'));
+    });
   });
 
   group('SimpleFIFOCache - Additional Behavior Validation', () {


### PR DESCRIPTION
## Summary

- Fixed a bug where unnecessary eviction occurred during value updates for existing keys by adding !_cache.containsKey(key) to the eviction condition in set().
- Affected Implementations: FIFOCache, SimpleFIFOCache, EphemeralFIFOCache, and SimpleEphemeralFIFOCache.
- Added regression tests for all four implementations to ensure that "eviction does not occur when updating an existing key."
- Updated 4 existing test cases that previously relied on incorrect eviction behavior to reflect correct FIFO semantics.

## Background

When the cache was full (_cache.length >= maxSize), updating the value of an existing key triggered the removal of the first entry, even though the total entry count did not increase. Following this fix, eviction is performed only when inserting a new key.

```dart
// Before
if (_cache.length >= maxSize) {
  _cache.remove(_cache.keys.first);
}

// After
if (!_cache.containsKey(key) && _cache.length >= maxSize) {
  _cache.remove(_cache.keys.first);
}
```

## Test plan

- [ ] Confirmed all 131 tests are passing via dart test.
- [ ] Covered scenarios for all 4 implementations ensuring no eviction occurs during existing key updates.
- [ ] Verified that standard FIFO eviction behavior for new key insertions remains unchanged.

