### PR TITLE
Fix unawaited Future bug in LFU/MRU eviction methods

### DIFF
--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -72,7 +72,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   }
 
   /// Performs eviction based on the LFU (Least Frequently Used) policy.
-  Future<void> _evictLFUEntry() async {
+  void _evictLFUEntry() {
     if (_cache.isEmpty) return;
 
     // Find the key with the lowest usage count

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -104,7 +104,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   }
 
   /// Performs eviction using the LFU (Least Frequently Used) policy.
-  Future<void> _evictLFUEntry() async {
+  void _evictLFUEntry() {
     if (_cache.isEmpty) return;
 
     final K lfuKey =

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -110,7 +110,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   }
 
   /// Performs eviction (removal) using the MRU (Most Recently Used) policy.
-  Future<void> _evictMRUEntry() async {
+  void _evictMRUEntry() {
     if (_cache.isEmpty) return;
 
     // Remove the last added key (most recently used key)

--- a/lib/src/caches/mru_cache.dart
+++ b/lib/src/caches/mru_cache.dart
@@ -77,7 +77,7 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
   }
 
   /// **Evicts the most recently used (MRU) entry.**
-  Future<void> _evictMRUEntry() async {
+  void _evictMRUEntry() {
     if (_cache.isEmpty) return;
 
     // Remove the last added key (most recently used key)


### PR DESCRIPTION
## Summary

- `_evictLFUEntry` in `LFUCache` and `MonitoredLFUCache` was declared `async` (returning `Future<void>`) despite containing only synchronous operations
- `_evictMRUEntry` in `MRUCache` and `MonitoredMRUCache` had the same issue
- Each method was called inside a `_lock.synchronized()` callback without being awaited, creating a silent unawaited-`Future` bug
- Fix: remove `async` and change return type to `void` in all four classes — aligning them with the already-correct `Simple*` variants

## Test plan

- [x] `dart analyze` — no issues
- [x] `dart test` — all 131 tests pass
- [x] No public API changes; behavior is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)