### PR TITLE
Fix spurious eviction and usage count reset in LFU set()

### DIFF
--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -63,6 +63,10 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
+      if (_cache.containsKey(key)) {
+        _cache[key] = value;
+        return;
+      }
       if (_cache.length >= maxSize) {
         _evictLFUEntry(); // Evict based on LFU policy
       }

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -95,6 +95,10 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
+      if (_cache.containsKey(key)) {
+        _cache[key] = value;
+        return;
+      }
       if (_cache.length >= maxSize) {
         _evictLFUEntry();
       }

--- a/lib/src/caches/simple_lfu_cache.dart
+++ b/lib/src/caches/simple_lfu_cache.dart
@@ -57,6 +57,10 @@ class SimpleLFUCache<K, V> extends SimpleCache<K, V> {
   /// **This method is not thread-safe.**
   @override
   void set(K key, V value) {
+    if (_cache.containsKey(key)) {
+      _cache[key] = value;
+      return;
+    }
     if (_cache.length >= maxSize) {
       _evictLFUEntry(); // Evict based on LFU policy
     }

--- a/test/caches/lfu_cache_test.dart
+++ b/test/caches/lfu_cache_test.dart
@@ -75,28 +75,25 @@ void main() {
       },
     );
 
-    test(
-      'set() on an existing key preserves its usage count',
-      () async {
-        final cache = LFUCache<String, String>(2);
-        await cache.set('key1', 'value1');
-        await cache.set('key2', 'value2');
+    test('set() on an existing key preserves its usage count', () async {
+      final cache = LFUCache<String, String>(2);
+      await cache.set('key1', 'value1');
+      await cache.set('key2', 'value2');
 
-        // Boost key1's usage count
-        await cache.get('key1');
-        await cache.get('key1');
+      // Boost key1's usage count
+      await cache.get('key1');
+      await cache.get('key1');
 
-        // Update key1 — count must be preserved, not reset to 1
-        await cache.set('key1', 'updated');
+      // Update key1 — count must be preserved, not reset to 1
+      await cache.set('key1', 'updated');
 
-        // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
-        await cache.set('key3', 'value3');
+      // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+      await cache.set('key3', 'value3');
 
-        expect(await cache.get('key2'), isNull);
-        expect(await cache.get('key1'), equals('updated'));
-        expect(await cache.get('key3'), equals('value3'));
-      },
-    );
+      expect(await cache.get('key2'), isNull);
+      expect(await cache.get('key1'), equals('updated'));
+      expect(await cache.get('key3'), equals('value3'));
+    });
   });
 
   group('LFUCache - Thread-safety Tests', () {

--- a/test/caches/lfu_cache_test.dart
+++ b/test/caches/lfu_cache_test.dart
@@ -59,6 +59,44 @@ void main() {
         ); // key3 is newly added and should remain
       },
     );
+
+    test(
+      'set() on an existing key when cache is full does not evict any entry',
+      () async {
+        final cache = LFUCache<String, String>(2);
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        await cache.set('key1', 'new_value1');
+
+        expect(await cache.get('key1'), equals('new_value1'));
+        expect(await cache.get('key2'), equals('value2'));
+        expect(cache.getKeys().length, equals(2));
+      },
+    );
+
+    test(
+      'set() on an existing key preserves its usage count',
+      () async {
+        final cache = LFUCache<String, String>(2);
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        // Boost key1's usage count
+        await cache.get('key1');
+        await cache.get('key1');
+
+        // Update key1 — count must be preserved, not reset to 1
+        await cache.set('key1', 'updated');
+
+        // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+        await cache.set('key3', 'value3');
+
+        expect(await cache.get('key2'), isNull);
+        expect(await cache.get('key1'), equals('updated'));
+        expect(await cache.get('key3'), equals('value3'));
+      },
+    );
   });
 
   group('LFUCache - Thread-safety Tests', () {

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -116,31 +116,28 @@ void main() {
       },
     );
 
-    test(
-      'set() on an existing key preserves its usage count',
-      () async {
-        final cache = MonitoredLFUCache<String, String>(
-          maxSize: 2,
-          alertConfig: config,
-        );
-        await cache.set('key1', 'value1');
-        await cache.set('key2', 'value2');
+    test('set() on an existing key preserves its usage count', () async {
+      final cache = MonitoredLFUCache<String, String>(
+        maxSize: 2,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.set('key2', 'value2');
 
-        // Boost key1's usage count
-        await cache.get('key1');
-        await cache.get('key1');
+      // Boost key1's usage count
+      await cache.get('key1');
+      await cache.get('key1');
 
-        // Update key1 — count must be preserved, not reset to 1
-        await cache.set('key1', 'updated');
+      // Update key1 — count must be preserved, not reset to 1
+      await cache.set('key1', 'updated');
 
-        // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
-        await cache.set('key3', 'value3');
+      // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+      await cache.set('key3', 'value3');
 
-        expect(await cache.get('key2'), isNull);
-        expect(await cache.get('key1'), equals('updated'));
-        expect(await cache.get('key3'), equals('value3'));
-      },
-    );
+      expect(await cache.get('key2'), isNull);
+      expect(await cache.get('key1'), equals('updated'));
+      expect(await cache.get('key3'), equals('value3'));
+    });
 
     test('Should throw an exception if maxSize is 0 or negative', () {
       expect(

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -98,6 +98,50 @@ void main() {
       expect(cache.getKeys(), isEmpty);
     });
 
+    test(
+      'set() on an existing key when cache is full does not evict any entry',
+      () async {
+        final cache = MonitoredLFUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        await cache.set('key1', 'new_value1');
+
+        expect(await cache.get('key1'), equals('new_value1'));
+        expect(await cache.get('key2'), equals('value2'));
+        expect(cache.getKeys().length, equals(2));
+      },
+    );
+
+    test(
+      'set() on an existing key preserves its usage count',
+      () async {
+        final cache = MonitoredLFUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        // Boost key1's usage count
+        await cache.get('key1');
+        await cache.get('key1');
+
+        // Update key1 — count must be preserved, not reset to 1
+        await cache.set('key1', 'updated');
+
+        // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+        await cache.set('key3', 'value3');
+
+        expect(await cache.get('key2'), isNull);
+        expect(await cache.get('key1'), equals('updated'));
+        expect(await cache.get('key3'), equals('value3'));
+      },
+    );
+
     test('Should throw an exception if maxSize is 0 or negative', () {
       expect(
         () =>

--- a/test/caches/simple_lfu_cache_test.dart
+++ b/test/caches/simple_lfu_cache_test.dart
@@ -88,6 +88,44 @@ void main() {
         ); // key3 should remain as it was newly added
       },
     );
+
+    test(
+      'set() on an existing key when cache is full does not evict any entry',
+      () {
+        final cache = SimpleLFUCache<String, String>(2);
+        cache.set('key1', 'value1');
+        cache.set('key2', 'value2');
+
+        cache.set('key1', 'new_value1');
+
+        expect(cache.get('key1'), equals('new_value1'));
+        expect(cache.get('key2'), equals('value2'));
+        expect(cache.getKeys().length, equals(2));
+      },
+    );
+
+    test(
+      'set() on an existing key does not reset its usage count',
+      () {
+        final cache = SimpleLFUCache<String, String>(2);
+        cache.set('key1', 'value1');
+        cache.set('key2', 'value2');
+
+        // Boost key1's usage count
+        cache.get('key1');
+        cache.get('key1');
+
+        // Update key1 — count must be preserved, not reset to 1
+        cache.set('key1', 'updated');
+
+        // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+        cache.set('key3', 'value3');
+
+        expect(cache.get('key2'), isNull);
+        expect(cache.get('key1'), equals('updated'));
+        expect(cache.get('key3'), equals('value3'));
+      },
+    );
   });
 
   group('SimpleLFUCache - Error Handling', () {

--- a/test/caches/simple_lfu_cache_test.dart
+++ b/test/caches/simple_lfu_cache_test.dart
@@ -104,28 +104,25 @@ void main() {
       },
     );
 
-    test(
-      'set() on an existing key does not reset its usage count',
-      () {
-        final cache = SimpleLFUCache<String, String>(2);
-        cache.set('key1', 'value1');
-        cache.set('key2', 'value2');
+    test('set() on an existing key does not reset its usage count', () {
+      final cache = SimpleLFUCache<String, String>(2);
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
 
-        // Boost key1's usage count
-        cache.get('key1');
-        cache.get('key1');
+      // Boost key1's usage count
+      cache.get('key1');
+      cache.get('key1');
 
-        // Update key1 — count must be preserved, not reset to 1
-        cache.set('key1', 'updated');
+      // Update key1 — count must be preserved, not reset to 1
+      cache.set('key1', 'updated');
 
-        // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
-        cache.set('key3', 'value3');
+      // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+      cache.set('key3', 'value3');
 
-        expect(cache.get('key2'), isNull);
-        expect(cache.get('key1'), equals('updated'));
-        expect(cache.get('key3'), equals('value3'));
-      },
-    );
+      expect(cache.get('key2'), isNull);
+      expect(cache.get('key1'), equals('updated'));
+      expect(cache.get('key3'), equals('value3'));
+    });
   });
 
   group('SimpleLFUCache - Error Handling', () {


### PR DESCRIPTION
## Summary

- All three LFU implementations (`LFUCache`, `SimpleLFUCache`, `MonitoredLFUCache`) called `_evictLFUEntry()` even when updating an existing key, silently removing an unrelated entry
- `_usageCounts[key] = 1` always overwrote the current count, resetting frequency history on every update
- Fixed by adding a `containsKey` early-return in `set()`: existing keys update the value only, new keys follow the full evict-then-insert path

## Test plan

- [x] `SimpleLFUCache`: updating existing key at full capacity does not evict — `set() on an existing key when cache is full does not evict any entry`
- [x] `SimpleLFUCache`: usage count preserved after update — `set() on an existing key does not reset its usage count`
- [x] `LFUCache`: same two cases (async)
- [x] `MonitoredLFUCache`: same two cases (async)
- [x] `dart test` passes with no regressions (137/137)

🤖 Generated with [Claude Code](https://claude.com/claude-code)