### PR TITLE
Fix unbounded memory growth in CacheMetrics

### DIFF
--- a/lib/src/monitorings/cache_metrics.dart
+++ b/lib/src/monitorings/cache_metrics.dart
@@ -3,7 +3,19 @@
 /// This class tracks cache hit rates, miss rates, request latencies (delays),
 /// and eviction events. It provides the data necessary to measure and check
 /// cache performance over time.
+///
+/// **Bounded storage**: latency samples are kept in a rolling window of the
+/// most recent [maxLatencySamples] (1 000) entries, and eviction timestamps
+/// are kept in a rolling window of the most recent [maxEvictionSamples]
+/// (10 000) entries. This prevents unbounded heap growth in long-running
+/// caches. As a result, [averageLatency] and [getLatencyPercentile] reflect
+/// only the most recent 1 000 hits, and [getRecentStats] eviction counts are
+/// accurate only while the requested window fits within the retained eviction
+/// history.
 class CacheMetrics {
+  static const int maxLatencySamples = 1000;
+  static const int maxEvictionSamples = 10000;
+
   int _hits = 0;
   int _misses = 0;
   int _totalRequests = 0;
@@ -56,6 +68,7 @@ class CacheMetrics {
   void recordHit(Duration latency) {
     _hits++;
     _totalRequests++;
+    if (_latencies.length >= maxLatencySamples) _latencies.removeAt(0);
     _latencies.add(latency);
   }
 
@@ -67,6 +80,7 @@ class CacheMetrics {
 
   /// Records a cache eviction event
   void recordEviction() {
+    if (_evictions.length >= maxEvictionSamples) _evictions.removeAt(0);
     _evictions.add(DateTime.now());
   }
 

--- a/test/monitorings/cache_metrics_test.dart
+++ b/test/monitorings/cache_metrics_test.dart
@@ -119,4 +119,124 @@ void main() {
       );
     });
   });
+
+  group('CacheMetrics - Bounded Storage', () {
+    test(
+      '_latencies does not exceed maxLatencySamples entries after many recordHit calls',
+      () {
+        final metrics = CacheMetrics();
+        // First hit: 0ms. Next maxLatencySamples hits: 100ms each.
+        // The 0ms entry is rolled off when the cap is reached.
+        metrics.recordHit(Duration.zero);
+        for (var i = 0; i < CacheMetrics.maxLatencySamples; i++) {
+          metrics.recordHit(const Duration(milliseconds: 100));
+        }
+        // Bounded (1 000 entries, all 100ms) → average = 100ms.
+        // Unbounded (1 001 entries) → average = 100 000 / 1 001 ≈ 99ms.
+        expect(metrics.averageLatency.inMilliseconds, equals(100));
+      },
+    );
+
+    test(
+      'averageLatency reflects the most recent maxLatencySamples after cap is exceeded',
+      () {
+        final metrics = CacheMetrics();
+        for (var i = 0; i < CacheMetrics.maxLatencySamples; i++) {
+          metrics.recordHit(Duration.zero);
+        }
+        metrics.recordHit(
+          Duration(milliseconds: CacheMetrics.maxLatencySamples),
+        );
+        // Bounded: oldest 0ms entry dropped → [0×999, 1000ms] → average = 1ms.
+        // Unbounded: [0×1000, 1000ms] → average = 1000/1001 ≈ 0ms.
+        expect(metrics.averageLatency.inMilliseconds, equals(1));
+      },
+    );
+
+    test(
+      'getLatencyPercentile operates on the most recent maxLatencySamples after cap',
+      () {
+        final metrics = CacheMetrics();
+        for (var i = 0; i < CacheMetrics.maxLatencySamples; i++) {
+          metrics.recordHit(const Duration(milliseconds: 5));
+        }
+        metrics.recordHit(const Duration(milliseconds: 100));
+        // Most-recent entry (100ms) must be retained; oldest 5ms entry is dropped.
+        expect(metrics.getLatencyPercentile(100).inMilliseconds, equals(100));
+        // 999 entries at 5ms dominate, so median is 5ms.
+        expect(metrics.getLatencyPercentile(50).inMilliseconds, equals(5));
+      },
+    );
+
+    test(
+      '_evictions does not exceed maxEvictionSamples entries after many recordEviction calls',
+      () {
+        final metrics = CacheMetrics();
+        for (var i = 0; i < CacheMetrics.maxEvictionSamples + 1; i++) {
+          metrics.recordEviction();
+        }
+        // All evictions happened now → all within a 1-minute window.
+        // evictions_per_minute = recentEvictions × 60000 / 60000 = recentEvictions.
+        // Bounded: 10 000. Unbounded: 10 001.
+        final stats = metrics.getRecentStats(const Duration(minutes: 1));
+        expect(
+          stats['evictions_per_minute'],
+          equals(CacheMetrics.maxEvictionSamples),
+        );
+      },
+    );
+
+    test(
+      'getRecentStats evictions_per_minute is correct when eviction count is within cap',
+      () {
+        final metrics = CacheMetrics();
+        for (var i = 0; i < 60; i++) {
+          metrics.recordEviction();
+        }
+        expect(
+          metrics.getRecentStats(
+            const Duration(minutes: 1),
+          )['evictions_per_minute'],
+          equals(60),
+        );
+      },
+    );
+
+    test(
+      'hits, misses, and totalRequests remain exact beyond the latency cap',
+      () {
+        final metrics = CacheMetrics();
+        const totalHits = CacheMetrics.maxLatencySamples * 2;
+        const totalMisses = 500;
+        for (var i = 0; i < totalHits; i++) {
+          metrics.recordHit(const Duration(milliseconds: 1));
+        }
+        for (var i = 0; i < totalMisses; i++) {
+          metrics.recordMiss();
+        }
+        expect(metrics.hits, equals(totalHits));
+        expect(metrics.misses, equals(totalMisses));
+        expect(metrics.totalRequests, equals(totalHits + totalMisses));
+      },
+    );
+
+    test('reset() clears bounded stores and resets counters to zero', () {
+      final metrics = CacheMetrics();
+      for (var i = 0; i < 100; i++) {
+        metrics.recordHit(const Duration(milliseconds: 5));
+        metrics.recordEviction();
+      }
+      metrics.reset();
+      expect(metrics.hits, equals(0));
+      expect(metrics.misses, equals(0));
+      expect(metrics.totalRequests, equals(0));
+      expect(metrics.averageLatency, equals(Duration.zero));
+      expect(
+        metrics.getRecentStats(
+          const Duration(minutes: 1),
+        )['evictions_per_minute'],
+        equals(0),
+      );
+    });
+  });
 }

--- a/test/monitorings/cache_metrics_test.dart
+++ b/test/monitorings/cache_metrics_test.dart
@@ -145,7 +145,7 @@ void main() {
           metrics.recordHit(Duration.zero);
         }
         metrics.recordHit(
-          Duration(milliseconds: CacheMetrics.maxLatencySamples),
+          const Duration(milliseconds: CacheMetrics.maxLatencySamples),
         );
         // Bounded: oldest 0ms entry dropped → [0×999, 1000ms] → average = 1ms.
         // Unbounded: [0×1000, 1000ms] → average = 1000/1001 ≈ 0ms.


### PR DESCRIPTION
## Summary

- `CacheMetrics._latencies` and `_evictions` grew without limit for long-running caches, causing silent heap exhaustion.
- Cap `_latencies` to a rolling window of the most recent 1 000 entries (`maxLatencySamples`); drop the oldest on overflow.
- Cap `_evictions` to the most recent 10 000 entries (`maxEvictionSamples`); same rolling-window strategy.
- All public API signatures are unchanged. Scalar counters (`hits`, `misses`, `totalRequests`) remain exact all-time aggregates.

## Trade-offs

- `averageLatency` and `getLatencyPercentile` reflect only the most recent 1 000 hits (documented in the class-level doc comment).
- `getRecentStats` eviction counts are accurate as long as the requested window fits within the retained 10 000-entry history.

## Test plan

- [x] `CacheMetrics - Bounded Storage: _latencies does not exceed maxLatencySamples` — verifies oldest entry is dropped at the cap
- [x] `averageLatency reflects the most recent maxLatencySamples after cap is exceeded` — confirms rolling-window semantics
- [x] `getLatencyPercentile operates on the most recent maxLatencySamples after cap` — confirms most-recent entry is retained
- [x] `_evictions does not exceed maxEvictionSamples` — verifies eviction list is bounded via `evictions_per_minute`
- [x] `getRecentStats evictions_per_minute is correct when within cap` — confirms normal-path accuracy
- [x] `hits, misses, and totalRequests remain exact beyond the latency cap` — no off-by-one from rolling window
- [x] `reset() clears bounded stores and resets counters to zero`
- [x] Full `dart test` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)