### PR TITLE
Fix miss latency silently discarded in CacheMetrics/CacheMonitoring

### DIFF
--- a/lib/src/monitorings/cache_metrics.dart
+++ b/lib/src/monitorings/cache_metrics.dart
@@ -9,7 +9,7 @@
 /// are kept in a rolling window of the most recent [maxEvictionSamples]
 /// (10 000) entries. This prevents unbounded heap growth in long-running
 /// caches. As a result, [averageLatency] and [getLatencyPercentile] reflect
-/// only the most recent 1 000 hits, and [getRecentStats] eviction counts are
+/// only the most recent 1 000 requests (hits and misses), and [getRecentStats] eviction counts are
 /// accurate only while the requested window fits within the retained eviction
 /// history.
 class CacheMetrics {
@@ -72,10 +72,14 @@ class CacheMetrics {
     _latencies.add(latency);
   }
 
-  /// Records a cache miss
-  void recordMiss() {
+  /// Records a cache miss with the given request latency.
+  /// [latency] is the [Duration] representing the request's latency.
+  /// Latency is recorded for every request (hit or miss).
+  void recordMiss(Duration latency) {
     _misses++;
     _totalRequests++;
+    if (_latencies.length >= maxLatencySamples) _latencies.removeAt(0);
+    _latencies.add(latency);
   }
 
   /// Records a cache eviction event

--- a/lib/src/monitorings/cache_monitoring.dart
+++ b/lib/src/monitorings/cache_monitoring.dart
@@ -16,7 +16,7 @@ mixin CacheMonitoring<K, V> {
     if (value != null) {
       metrics.recordHit(stopwatch.elapsed);
     } else {
-      metrics.recordMiss();
+      metrics.recordMiss(stopwatch.elapsed);
     }
     return value;
   }

--- a/test/monitorings/cache_alert_manager_test.dart
+++ b/test/monitorings/cache_alert_manager_test.dart
@@ -32,7 +32,7 @@ void main() {
     test('Triggers alert when hit rate is too low', () async {
       // 90% of requests are misses
       for (int i = 0; i < 10; i++) {
-        metrics.recordMiss();
+        metrics.recordMiss(Duration.zero);
       }
       metrics.recordHit(const Duration(milliseconds: 10));
 
@@ -54,7 +54,7 @@ void main() {
     test('Triggers alert when miss rate is too high', () async {
       // 80% of requests are misses
       for (int i = 0; i < 8; i++) {
-        metrics.recordMiss();
+        metrics.recordMiss(Duration.zero);
       }
       for (int i = 0; i < 2; i++) {
         metrics.recordHit(const Duration(milliseconds: 10));

--- a/test/monitorings/cache_metrics_test.dart
+++ b/test/monitorings/cache_metrics_test.dart
@@ -8,9 +8,9 @@ void main() {
 
       metrics.recordHit(const Duration(milliseconds: 10));
       metrics.recordHit(const Duration(milliseconds: 20));
-      metrics.recordMiss();
-      metrics.recordMiss();
-      metrics.recordMiss();
+      metrics.recordMiss(Duration.zero);
+      metrics.recordMiss(Duration.zero);
+      metrics.recordMiss(Duration.zero);
 
       expect(metrics.hits, equals(2));
       expect(metrics.misses, equals(3));
@@ -22,8 +22,8 @@ void main() {
 
       metrics.recordHit(const Duration(milliseconds: 10));
       metrics.recordHit(const Duration(milliseconds: 20));
-      metrics.recordMiss();
-      metrics.recordMiss();
+      metrics.recordMiss(Duration.zero);
+      metrics.recordMiss(Duration.zero);
 
       expect(metrics.hitRate, closeTo(0.5, 0.01)); // 2/4 = 0.5
       expect(metrics.missRate, closeTo(0.5, 0.01)); // 2/4 = 0.5
@@ -51,6 +51,17 @@ void main() {
       ); // 100th percentile = max value
     });
 
+    test('averageLatency includes miss samples', () {
+      final metrics = CacheMetrics();
+
+      metrics.recordHit(const Duration(milliseconds: 10));
+      metrics.recordHit(const Duration(milliseconds: 20));
+      metrics.recordMiss(const Duration(milliseconds: 30));
+
+      // (10 + 20 + 30) / 3 = 20ms
+      expect(metrics.averageLatency.inMilliseconds, equals(20));
+    });
+
     test('Evictions are recorded correctly', () {
       final metrics = CacheMetrics();
 
@@ -74,7 +85,7 @@ void main() {
         final metrics = CacheMetrics();
 
         metrics.recordHit(const Duration(milliseconds: 15));
-        metrics.recordMiss();
+        metrics.recordMiss(Duration.zero);
         metrics.recordEviction();
 
         await Future.delayed(
@@ -82,7 +93,7 @@ void main() {
         ); // Simulate passage of time
 
         metrics.recordHit(const Duration(milliseconds: 25));
-        metrics.recordMiss();
+        metrics.recordMiss(Duration.zero);
         metrics.recordEviction();
 
         final recentStats = metrics.getRecentStats(const Duration(seconds: 1));
@@ -102,7 +113,7 @@ void main() {
       final metrics = CacheMetrics();
 
       metrics.recordHit(const Duration(milliseconds: 10));
-      metrics.recordMiss();
+      metrics.recordMiss(Duration.zero);
       metrics.recordEviction();
 
       metrics.reset();
@@ -212,7 +223,7 @@ void main() {
           metrics.recordHit(const Duration(milliseconds: 1));
         }
         for (var i = 0; i < totalMisses; i++) {
-          metrics.recordMiss();
+          metrics.recordMiss(Duration.zero);
         }
         expect(metrics.hits, equals(totalHits));
         expect(metrics.misses, equals(totalMisses));


### PR DESCRIPTION
## Summary

- `CacheMetrics.recordMiss()` now requires a `Duration latency` parameter and appends it to `_latencies`, so `averageLatency` and percentile stats reflect every request (hit or miss), not only hits
- `CacheMonitoring.monitoredGet()` passes `stopwatch.elapsed` to `recordMiss()` on cache miss, closing the silent measurement gap
- All call-sites updated (`cache_metrics_test.dart`, `cache_alert_manager_test.dart`) and a new test added to verify aggregate latency across mixed hit/miss workloads

## Background

`monitoredGet()` measured elapsed time for every request but called `recordMiss()` with no argument, silently discarding the measurement. This meant `averageLatency` and `getLatencyPercentile` only reflected hit latency — producing misleading results in any mixed hit/miss workload.

The fix makes the broken pattern a compile error: `recordMiss(Duration latency)` is a **required** parameter with no default, so every caller must supply a real measurement.

## Test plan

- [x] `averageLatency includes miss samples` — new test confirms hits + misses are combined correctly
- [x] All existing `recordMiss()` call-sites updated with `Duration.zero` (irrelevant to assertion) or meaningful values
- [x] Full test suite passes: `dart test` → 145/145 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)