### PR TITLE
chore: release v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.5 - Bug Fixes
+
+- Fixed spurious eviction in FIFO `set()` when updating an existing key.
+- Fixed unawaited `Future` in LFU/MRU eviction causing silent async errors.
+- Fixed LFU `set()` incorrectly resetting usage count and spuriously evicting when updating an existing key.
+- Fixed unbounded memory growth in `CacheMetrics` by capping stored latency samples.
+- Fixed miss latency silently discarded in `CacheMetrics`/`CacheMonitoring`.
+- Fixed incorrect cache descriptions for LRU and MRU.
+
 ## 1.1.4 - Add Project Logo to README
 
 - Added project logo to README header for improved visual branding.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cacherine
 description: A Dart library offering flexible in-memory cache implementations (FIFO, LRU, MRU, LFU) with both single-threaded and async options for concurrent environments.
-version: 1.1.4
+version: 1.1.5
 repository: https://github.com/yordgenome03/cacherine
 
 dependencies:


### PR DESCRIPTION
## Summary

This PR bumps the version to `1.1.5` and adds the corresponding CHANGELOG entry, collecting five bug fixes that have landed on `main` since the `v1.1.4` tag.

### Bug fixes included

- Fixed spurious eviction in FIFO `set()` when updating an existing key.
- Fixed unawaited `Future` in LFU/MRU eviction causing silent async errors.
- Fixed LFU `set()` incorrectly resetting usage count and spuriously evicting when updating an existing key.
- Fixed unbounded memory growth in `CacheMetrics` by capping stored latency samples.
- Fixed miss latency silently discarded in `CacheMetrics`/`CacheMonitoring`.

### Files changed

- `pubspec.yaml`: version `1.1.4` → `1.1.5`
- `CHANGELOG.md`: prepend `## 1.1.5` section

### No breaking changes

No public API was added or removed. All existing tests pass.

### Publishing note

After merging, please run `dart pub publish` to publish `1.1.5` to pub.dev.