### PR TITLE
feat: add remove(key) for manual cache eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.2.0 - Add Manual Cache Eviction
+
+### Breaking Changes
+
+- `SimpleCache<K, V>` now requires implementing `void remove(K key)`. Any external class that directly implements `SimpleCache` (rather than extending a built-in implementation) must add this method.
+- `ThreadSafeCache<K, V>` now requires implementing `Future<void> remove(K key)`. Same caveat applies.
+
+### New Features
+
+- `remove(K key)` on all `SimpleCache` implementations (`SimpleLRUCache`, `SimpleMRUCache`, `SimpleLFUCache`, `SimpleFIFOCache`, `SimpleEphemeralFIFOCache`): synchronously removes a single entry; no-op if the key does not exist.
+- `remove(K key)` on all `ThreadSafeCache` implementations (`LRUCache`, `MRUCache`, `LFUCache`, `FIFOCache`, `EphemeralFIFOCache`): asynchronously removes a single entry under the instance lock; no-op if the key does not exist.
+- `remove(K key)` on all `Monitored*` wrappers (`MonitoredLRUCache`, `MonitoredMRUCache`, `MonitoredLFUCache`, `MonitoredFIFOCache`, `MonitoredEphemeralFIFOCache`): delegates to the underlying cache and calls `CacheMetrics.recordEviction()` when the key existed, so manual evictions are reflected in `evictions_per_minute` and related metrics.
+
 ## 1.1.5 - Bug Fixes
 
 - Fixed spurious eviction in FIFO `set()` when updating an existing key.

--- a/lib/src/caches/ephemeral_fifo_cache.dart
+++ b/lib/src/caches/ephemeral_fifo_cache.dart
@@ -74,6 +74,18 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is thread-safe.**
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      _cache.remove(key);
+    });
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/caches/fifo_cache.dart
+++ b/lib/src/caches/fifo_cache.dart
@@ -68,6 +68,19 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  /// - This is an O(n) operation because the underlying LinkedHashMap must be scanned.
+  ///
+  /// **This method is thread-safe.**
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      _cache.remove(key);
+    });
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -88,6 +88,20 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
     _usageCounts.remove(lfuKey);
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  /// - The frequency counter for the key is also discarded.
+  ///
+  /// **This method is thread-safe.**
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      _cache.remove(key);
+      _usageCounts.remove(key);
+    });
+  }
+
   /// Clears the cache, removing all stored data.
   ///
   /// **This method is thread-safe.**

--- a/lib/src/caches/lru_cache.dart
+++ b/lib/src/caches/lru_cache.dart
@@ -77,6 +77,18 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is thread-safe.**
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      _cache.remove(key);
+    });
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -97,6 +97,22 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
     });
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key existed, records a manual eviction via [CacheMonitoring].
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is thread-safe**.
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      if (_cache.containsKey(key)) {
+        _cache.remove(key);
+        metrics.recordEviction();
+      }
+    });
+  }
+
   /// Clears the cache and removes all data.
   ///
   /// - The monitoring function remains active even after the cache is cleared.

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -102,6 +102,22 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
     });
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key existed, records a manual eviction via [CacheMonitoring].
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is thread-safe.**
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      if (_cache.containsKey(key)) {
+        _cache.remove(key);
+        metrics.recordEviction();
+      }
+    });
+  }
+
   /// Clears the cache and removes all data.
   ///
   /// - The monitoring function remains active even after the cache is cleared.

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -118,6 +118,24 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
     _usageCounts.remove(lfuKey);
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key existed, records a manual eviction via [CacheMonitoring].
+  /// - If the key does not exist, this call is a no-op.
+  /// - The frequency counter for the key is also discarded.
+  ///
+  /// **This method is thread-safe**.
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      if (_cache.containsKey(key)) {
+        _cache.remove(key);
+        _usageCounts.remove(key);
+        metrics.recordEviction();
+      }
+    });
+  }
+
   /// Clears the cache and removes all data.
   ///
   /// - The monitoring function remains active even after the cache is cleared.

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -110,6 +110,22 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
     });
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key existed, records a manual eviction via [CacheMonitoring].
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is thread-safe**.
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      if (_cache.containsKey(key)) {
+        _cache.remove(key);
+        metrics.recordEviction();
+      }
+    });
+  }
+
   /// Clears the cache and removes all data.
   ///
   /// - The monitoring function remains active even after the cache is cleared.

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -118,6 +118,22 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
     _cache.remove(mruKey);
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key existed, records a manual eviction via [CacheMonitoring].
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is thread-safe**.
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      if (_cache.containsKey(key)) {
+        _cache.remove(key);
+        metrics.recordEviction();
+      }
+    });
+  }
+
   /// Clears the cache and removes all data.
   ///
   /// - The monitoring function remains active even after the cache is cleared.

--- a/lib/src/caches/mru_cache.dart
+++ b/lib/src/caches/mru_cache.dart
@@ -85,6 +85,18 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
     _cache.remove(mruKey);
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is thread-safe.**
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      _cache.remove(key);
+    });
+  }
+
   /// Clears the cache, removing all stored data.
   ///
   /// **This method is thread-safe.**

--- a/lib/src/caches/simple_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/simple_ephemeral_fifo_cache.dart
@@ -62,6 +62,16 @@ class SimpleEphemeralFIFOCache<K, V> extends SimpleCache<K, V> {
     _cache[key] = value; // Update value (order remains unchanged)
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void remove(K key) {
+    _cache.remove(key);
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/caches/simple_fifo_cache.dart
+++ b/lib/src/caches/simple_fifo_cache.dart
@@ -61,6 +61,16 @@ class SimpleFIFOCache<K, V> extends SimpleCache<K, V> {
     _cache[key] = value; // Update value (order remains unchanged)
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void remove(K key) {
+    _cache.remove(key);
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/caches/simple_lfu_cache.dart
+++ b/lib/src/caches/simple_lfu_cache.dart
@@ -81,6 +81,18 @@ class SimpleLFUCache<K, V> extends SimpleCache<K, V> {
     _usageCounts.remove(lfuKey);
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  /// - The frequency counter for the key is also discarded.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void remove(K key) {
+    _cache.remove(key);
+    _usageCounts.remove(key);
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/caches/simple_lru_cache.dart
+++ b/lib/src/caches/simple_lru_cache.dart
@@ -69,6 +69,16 @@ class SimpleLRUCache<K, V> extends SimpleCache<K, V> {
     _cache[key] = value;
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void remove(K key) {
+    _cache.remove(key);
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/caches/simple_mru_cache.dart
+++ b/lib/src/caches/simple_mru_cache.dart
@@ -78,6 +78,16 @@ class SimpleMRUCache<K, V> extends SimpleCache<K, V> {
     _cache.remove(mruKey);
   }
 
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void remove(K key) {
+    _cache.remove(key);
+  }
+
   /// Clears all data stored in the cache.
   ///
   /// - Removes all keys and values from the cache.

--- a/lib/src/interfaces/simple_cache.dart
+++ b/lib/src/interfaces/simple_cache.dart
@@ -28,6 +28,14 @@ abstract class SimpleCache<K, V> {
   /// - `value`: The value of the data to store.
   void set(K key, V value);
 
+  /// **Removes the entry with the given key from the cache.**
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **Arguments:**
+  /// - `key`: The key of the entry to remove.
+  void remove(K key);
+
   /// **Removes all data stored in the cache.**
   void clear();
 }

--- a/lib/src/interfaces/thread_safe_cache.dart
+++ b/lib/src/interfaces/thread_safe_cache.dart
@@ -29,6 +29,15 @@ abstract class ThreadSafeCache<K, V> {
   /// - `value`: The value of the data to store.
   Future<void> set(K key, V value);
 
+  /// **Removes the entry with the given key from the cache (asynchronously).**
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  /// - The operation is executed inside the instance's lock to prevent data races.
+  ///
+  /// **Arguments:**
+  /// - `key`: The key of the entry to remove.
+  Future<void> remove(K key);
+
   /// **Removes all data stored in the cache (asynchronously).**
   Future<void> clear();
 }

--- a/test/caches/ephemeral_fifo_cache_test.dart
+++ b/test/caches/ephemeral_fifo_cache_test.dart
@@ -156,4 +156,29 @@ void main() {
       expect(() => EphemeralFIFOCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('EphemeralFIFOCache - remove()', () {
+    test('remove() existing key makes subsequent get() return null', () async {
+      final cache = EphemeralFIFOCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () async {
+      final cache = EphemeralFIFOCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('missing');
+      // Use getKeys() — calling get() would consume the ephemeral entry
+      expect(cache.getKeys(), contains('key1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+
+    test('remove() Future completes without error', () async {
+      final cache = EphemeralFIFOCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await expectLater(cache.remove('key1'), completes);
+    });
+  });
 }

--- a/test/caches/fifo_cache_test.dart
+++ b/test/caches/fifo_cache_test.dart
@@ -154,4 +154,28 @@ void main() {
       expect(() => FIFOCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('FIFOCache - remove()', () {
+    test('remove() existing key makes subsequent get() return null', () async {
+      final cache = FIFOCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () async {
+      final cache = FIFOCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('missing');
+      expect(await cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+
+    test('remove() Future completes without error', () async {
+      final cache = FIFOCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await expectLater(cache.remove('key1'), completes);
+    });
+  });
 }

--- a/test/caches/lfu_cache_test.dart
+++ b/test/caches/lfu_cache_test.dart
@@ -137,4 +137,28 @@ void main() {
       expect(() => LFUCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('LFUCache - remove()', () {
+    test('remove() existing key makes subsequent get() return null', () async {
+      final cache = LFUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () async {
+      final cache = LFUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('missing');
+      expect(await cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+
+    test('remove() Future completes without error', () async {
+      final cache = LFUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await expectLater(cache.remove('key1'), completes);
+    });
+  });
 }

--- a/test/caches/lru_cache_test.dart
+++ b/test/caches/lru_cache_test.dart
@@ -116,4 +116,28 @@ void main() {
       expect(() => LRUCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('LRUCache - remove()', () {
+    test('remove() existing key makes subsequent get() return null', () async {
+      final cache = LRUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () async {
+      final cache = LRUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('missing');
+      expect(await cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+
+    test('remove() Future completes without error', () async {
+      final cache = LRUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await expectLater(cache.remove('key1'), completes);
+    });
+  });
 }

--- a/test/caches/monitored_ephemeral_fifo_cache_test.dart
+++ b/test/caches/monitored_ephemeral_fifo_cache_test.dart
@@ -104,4 +104,30 @@ void main() {
       );
     });
   });
+
+  group('MonitoredEphemeralFIFOCache - remove()', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('remove() existing key records eviction in metrics', () async {
+      final cache = MonitoredEphemeralFIFOCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
+    });
+
+    test('remove() non-existent key does not record eviction', () async {
+      final cache = MonitoredEphemeralFIFOCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.remove('missing');
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(0));
+    });
+  });
 }

--- a/test/caches/monitored_fifo_cache_test.dart
+++ b/test/caches/monitored_fifo_cache_test.dart
@@ -99,4 +99,30 @@ void main() {
       );
     });
   });
+
+  group('MonitoredFIFOCache - remove()', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('remove() existing key records eviction in metrics', () async {
+      final cache = MonitoredFIFOCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
+    });
+
+    test('remove() non-existent key does not record eviction', () async {
+      final cache = MonitoredFIFOCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.remove('missing');
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(0));
+    });
+  });
 }

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -147,4 +147,30 @@ void main() {
       );
     });
   });
+
+  group('MonitoredLFUCache - remove()', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('remove() existing key records eviction in metrics', () async {
+      final cache = MonitoredLFUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
+    });
+
+    test('remove() non-existent key does not record eviction', () async {
+      final cache = MonitoredLFUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.remove('missing');
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(0));
+    });
+  });
 }

--- a/test/caches/monitored_lru_cache_test.dart
+++ b/test/caches/monitored_lru_cache_test.dart
@@ -103,4 +103,30 @@ void main() {
       );
     });
   });
+
+  group('MonitoredLRUCache - remove()', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('remove() existing key records eviction in metrics', () async {
+      final cache = MonitoredLRUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
+    });
+
+    test('remove() non-existent key does not record eviction', () async {
+      final cache = MonitoredLRUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.remove('missing');
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(0));
+    });
+  });
 }

--- a/test/caches/monitored_mru_cache_test.dart
+++ b/test/caches/monitored_mru_cache_test.dart
@@ -100,4 +100,30 @@ void main() {
       );
     });
   });
+
+  group('MonitoredMRUCache - remove()', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('remove() existing key records eviction in metrics', () async {
+      final cache = MonitoredMRUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
+    });
+
+    test('remove() non-existent key does not record eviction', () async {
+      final cache = MonitoredMRUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      await cache.remove('missing');
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(0));
+    });
+  });
 }

--- a/test/caches/mru_cache_test.dart
+++ b/test/caches/mru_cache_test.dart
@@ -70,4 +70,28 @@ void main() {
       expect(() => MRUCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('MRUCache - remove()', () {
+    test('remove() existing key makes subsequent get() return null', () async {
+      final cache = MRUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('key1');
+      expect(await cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () async {
+      final cache = MRUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await cache.remove('missing');
+      expect(await cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+
+    test('remove() Future completes without error', () async {
+      final cache = MRUCache<String, String>(3);
+      await cache.set('key1', 'value1');
+      await expectLater(cache.remove('key1'), completes);
+    });
+  });
 }

--- a/test/caches/simple_ephemeral_fifo_cache_test.dart
+++ b/test/caches/simple_ephemeral_fifo_cache_test.dart
@@ -136,4 +136,23 @@ void main() {
       );
     });
   });
+
+  group('SimpleEphemeralFIFOCache - remove()', () {
+    test('remove() existing key makes get() return null', () {
+      final cache = SimpleEphemeralFIFOCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('key1');
+      expect(cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () {
+      final cache = SimpleEphemeralFIFOCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('missing');
+      // Use getKeys() — calling get() would consume the ephemeral entry
+      expect(cache.getKeys(), contains('key1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+  });
 }

--- a/test/caches/simple_fifo_cache_test.dart
+++ b/test/caches/simple_fifo_cache_test.dart
@@ -137,4 +137,22 @@ void main() {
       expect(() => SimpleFIFOCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('SimpleFIFOCache - remove()', () {
+    test('remove() existing key makes get() return null', () {
+      final cache = SimpleFIFOCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('key1');
+      expect(cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () {
+      final cache = SimpleFIFOCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('missing');
+      expect(cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+  });
 }

--- a/test/caches/simple_lfu_cache_test.dart
+++ b/test/caches/simple_lfu_cache_test.dart
@@ -149,19 +149,22 @@ void main() {
       expect(cache.getKeys().length, equals(1));
     });
 
-    test('remove() discards frequency counter so LFU ordering is unaffected', () {
-      final cache = SimpleLFUCache<String, String>(2);
-      cache.set('key1', 'value1');
-      cache.set('key2', 'value2');
-      cache.get('key2'); // key2 freq=2, key1 freq=1
-      cache.remove('key1');
-      // Re-add key1 — should start fresh with freq=1
-      cache.set('key1', 'new1');
-      // key1 (freq=1) is LFU; inserting key3 should evict key1
-      cache.set('key3', 'value3');
-      expect(cache.get('key1'), isNull);
-      expect(cache.get('key2'), equals('value2'));
-      expect(cache.get('key3'), equals('value3'));
-    });
+    test(
+      'remove() discards frequency counter so LFU ordering is unaffected',
+      () {
+        final cache = SimpleLFUCache<String, String>(2);
+        cache.set('key1', 'value1');
+        cache.set('key2', 'value2');
+        cache.get('key2'); // key2 freq=2, key1 freq=1
+        cache.remove('key1');
+        // Re-add key1 — should start fresh with freq=1
+        cache.set('key1', 'new1');
+        // key1 (freq=1) is LFU; inserting key3 should evict key1
+        cache.set('key3', 'value3');
+        expect(cache.get('key1'), isNull);
+        expect(cache.get('key2'), equals('value2'));
+        expect(cache.get('key3'), equals('value3'));
+      },
+    );
   });
 }

--- a/test/caches/simple_lfu_cache_test.dart
+++ b/test/caches/simple_lfu_cache_test.dart
@@ -131,4 +131,37 @@ void main() {
       expect(() => SimpleLFUCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('SimpleLFUCache - remove()', () {
+    test('remove() existing key makes get() return null', () {
+      final cache = SimpleLFUCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('key1');
+      expect(cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () {
+      final cache = SimpleLFUCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('missing');
+      expect(cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+
+    test('remove() discards frequency counter so LFU ordering is unaffected', () {
+      final cache = SimpleLFUCache<String, String>(2);
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
+      cache.get('key2'); // key2 freq=2, key1 freq=1
+      cache.remove('key1');
+      // Re-add key1 — should start fresh with freq=1
+      cache.set('key1', 'new1');
+      // key1 (freq=1) is LFU; inserting key3 should evict key1
+      cache.set('key3', 'value3');
+      expect(cache.get('key1'), isNull);
+      expect(cache.get('key2'), equals('value2'));
+      expect(cache.get('key3'), equals('value3'));
+    });
+  });
 }

--- a/test/caches/simple_lru_cache_test.dart
+++ b/test/caches/simple_lru_cache_test.dart
@@ -96,4 +96,36 @@ void main() {
       expect(() => SimpleLRUCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('SimpleLRUCache - remove()', () {
+    test('remove() existing key makes get() return null', () {
+      final cache = SimpleLRUCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('key1');
+      expect(cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () {
+      final cache = SimpleLRUCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('missing');
+      expect(cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+
+    test('remove() does not affect LRU ordering of remaining entries', () {
+      final cache = SimpleLRUCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.set('key2', 'value2');
+      cache.set('key3', 'value3');
+      // LRU order: key1 (LRU), key2, key3 (MRU)
+      cache.remove('key2'); // remove middle entry
+      // Remaining: key1 (LRU), key3 (MRU)
+      expect(cache.get('key1'), equals('value1'));
+      expect(cache.get('key3'), equals('value3'));
+      expect(cache.getKeys(), isNot(contains('key2')));
+      expect(cache.getKeys().length, equals(2));
+    });
+  });
 }

--- a/test/caches/simple_mru_cache_test.dart
+++ b/test/caches/simple_mru_cache_test.dart
@@ -84,4 +84,22 @@ void main() {
       expect(() => SimpleMRUCache<String, String>(-1), throwsArgumentError);
     });
   });
+
+  group('SimpleMRUCache - remove()', () {
+    test('remove() existing key makes get() return null', () {
+      final cache = SimpleMRUCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('key1');
+      expect(cache.get('key1'), isNull);
+      expect(cache.getKeys(), isNot(contains('key1')));
+    });
+
+    test('remove() non-existent key is a no-op', () {
+      final cache = SimpleMRUCache<String, String>(3);
+      cache.set('key1', 'value1');
+      cache.remove('missing');
+      expect(cache.get('key1'), equals('value1'));
+      expect(cache.getKeys().length, equals(1));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Adds `void remove(K key)` to `SimpleCache<K, V>` and `Future<void> remove(K key)` to `ThreadSafeCache<K, V>`
- Implements `remove` in all 10 concrete classes (5 Simple*, 5 ThreadSafe) and 5 Monitored* wrappers
- Monitored* wrappers call `CacheMetrics.recordEviction()` only when the key existed, keeping `evictions_per_minute` accurate for manual evictions
- Missing-key calls are always no-ops (no exception thrown)

Closes #28

## Breaking Change

Any external code that **implements** (not just uses) `SimpleCache` or `ThreadSafeCache` must add the new `remove` method. See `CHANGELOG.md` for details.

## Test plan

- [x] Unit tests added for all 5 `Simple*` implementations (existing key, missing key, post-remove `get` returns null)
- [x] Unit tests added for all 5 `ThreadSafeCache` implementations (same cases + async `Future` completion)
- [x] Unit tests added for all 5 `Monitored*` wrappers (eviction recorded on hit; not recorded on miss)
- [x] Full test suite passes with no regressions: `dart test` → 182 tests passed
- [x] `dart analyze lib/` → No issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)