### PR TITLE
fix: improve CacheMetrics efficiency and ThreadSafeCache lock consistency

### DIFF
--- a/lib/src/caches/ephemeral_fifo_cache.dart
+++ b/lib/src/caches/ephemeral_fifo_cache.dart
@@ -39,8 +39,10 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// **This method is thread-safe.**
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value associated with the specified key and **removes the key from the cache**.

--- a/lib/src/caches/fifo_cache.dart
+++ b/lib/src/caches/fifo_cache.dart
@@ -32,8 +32,10 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// **This method is thread-safe.**
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value associated with the specified key.

--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -33,8 +33,10 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// **This method is thread-safe.**
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value associated with the specified key and increments its usage count.

--- a/lib/src/caches/lru_cache.dart
+++ b/lib/src/caches/lru_cache.dart
@@ -32,8 +32,10 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// **This method is thread-safe.**
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value associated with the specified key.

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -60,8 +60,10 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// **This method is thread-safe**.
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value for the specified key and **removes the key from the cache**.

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -64,8 +64,10 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// **This method is thread-safe**, taking a snapshot of the cache before returning the keys.
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value for the specified key.

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -64,8 +64,10 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// **This method is thread-safe**, taking a snapshot of the cache before returning the keys.
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value for the specified key and increments its usage count.

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -64,8 +64,10 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// **This method is thread-safe**, taking a snapshot of the cache before returning the keys.
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value for the specified key.

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -63,8 +63,10 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// **This method is thread-safe**.
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// Retrieves the value for the specified key.

--- a/lib/src/caches/mru_cache.dart
+++ b/lib/src/caches/mru_cache.dart
@@ -32,8 +32,10 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// **This method is thread-safe.**
   @override
-  Iterable<K> getKeys() {
-    return Map<K, V>.of(_cache).keys;
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      return Map<K, V>.of(_cache).keys;
+    });
   }
 
   /// **Retrieves the value associated with the specified key.**

--- a/lib/src/interfaces/thread_safe_cache.dart
+++ b/lib/src/interfaces/thread_safe_cache.dart
@@ -7,8 +7,8 @@
 abstract class ThreadSafeCache<K, V> {
   /// **Retrieves all keys stored in the cache.**
   ///
-  /// **Returns:** A list of all keys in the cache.
-  Iterable<K> getKeys();
+  /// **Returns:** A snapshot of all keys in the cache at the time of the call.
+  Future<Iterable<K>> getKeys();
 
   /// **Retrieves the value associated with the specified key (asynchronously).**
   ///

--- a/lib/src/monitorings/cache_metrics.dart
+++ b/lib/src/monitorings/cache_metrics.dart
@@ -110,7 +110,8 @@ class CacheMetrics {
       'p95_latency': getLatencyPercentile(95).inMilliseconds,
       'p99_latency': getLatencyPercentile(99).inMilliseconds,
       'evictions_per_minute':
-          (recentEvictions * 60000000) ~/ window.inMicroseconds,
+          (recentEvictions * Duration.microsecondsPerMinute) ~/
+          window.inMicroseconds,
     };
   }
 

--- a/lib/src/monitorings/cache_metrics.dart
+++ b/lib/src/monitorings/cache_metrics.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 /// Cache performance metrics class
 ///
 /// This class tracks cache hit rates, miss rates, request latencies (delays),
@@ -19,8 +21,8 @@ class CacheMetrics {
   int _hits = 0;
   int _misses = 0;
   int _totalRequests = 0;
-  final List<Duration> _latencies = [];
-  final List<DateTime> _evictions = [];
+  final Queue<Duration> _latencies = Queue();
+  final Queue<DateTime> _evictions = Queue();
 
   /// The number of cache hits
   int get hits => _hits;
@@ -68,7 +70,7 @@ class CacheMetrics {
   void recordHit(Duration latency) {
     _hits++;
     _totalRequests++;
-    if (_latencies.length >= maxLatencySamples) _latencies.removeAt(0);
+    if (_latencies.length >= maxLatencySamples) _latencies.removeFirst();
     _latencies.add(latency);
   }
 
@@ -78,18 +80,25 @@ class CacheMetrics {
   void recordMiss(Duration latency) {
     _misses++;
     _totalRequests++;
-    if (_latencies.length >= maxLatencySamples) _latencies.removeAt(0);
+    if (_latencies.length >= maxLatencySamples) _latencies.removeFirst();
     _latencies.add(latency);
   }
 
   /// Records a cache eviction event
   void recordEviction() {
-    if (_evictions.length >= maxEvictionSamples) _evictions.removeAt(0);
+    if (_evictions.length >= maxEvictionSamples) _evictions.removeFirst();
     _evictions.add(DateTime.now());
   }
 
   /// Retrieves the recent cache statistics within a given time window.
+  ///
+  /// Throws [ArgumentError] if [window] is zero or negative.
   Map<String, dynamic> getRecentStats(Duration window) {
+    if (window.inMilliseconds <= 0) {
+      throw ArgumentError(
+        'window must be a positive Duration, but was $window',
+      );
+    }
     final now = DateTime.now();
     final windowStart = now.subtract(window);
     final recentEvictions =

--- a/lib/src/monitorings/cache_metrics.dart
+++ b/lib/src/monitorings/cache_metrics.dart
@@ -94,7 +94,7 @@ class CacheMetrics {
   ///
   /// Throws [ArgumentError] if [window] is zero or negative.
   Map<String, dynamic> getRecentStats(Duration window) {
-    if (window.inMilliseconds <= 0) {
+    if (window.inMicroseconds <= 0) {
       throw ArgumentError(
         'window must be a positive Duration, but was $window',
       );
@@ -110,7 +110,7 @@ class CacheMetrics {
       'p95_latency': getLatencyPercentile(95).inMilliseconds,
       'p99_latency': getLatencyPercentile(99).inMilliseconds,
       'evictions_per_minute':
-          (recentEvictions * 60000) ~/ window.inMilliseconds,
+          (recentEvictions * 60000000) ~/ window.inMicroseconds,
     };
   }
 

--- a/test/caches/ephemeral_fifo_cache_test.dart
+++ b/test/caches/ephemeral_fifo_cache_test.dart
@@ -32,7 +32,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
   });
 
@@ -83,8 +83,8 @@ void main() {
 
         await cache.set('B', 'newValueB'); // update existing key — no eviction
 
-        expect(cache.getKeys().length, equals(3));
-        expect(cache.getKeys(), containsAll(['A', 'B', 'C']));
+        expect((await cache.getKeys()).length, equals(3));
+        expect(await cache.getKeys(), containsAll(['A', 'B', 'C']));
         expect(await cache.get('B'), equals('newValueB'));
       },
     );
@@ -109,7 +109,7 @@ void main() {
       await Future.wait(futures);
 
       // Confirm that no values are left in the cache
-      expect(cache.getKeys().isEmpty, isTrue);
+      expect((await cache.getKeys()).isEmpty, isTrue);
     });
 
     test('Parallel clear() calls remove all data', () async {
@@ -124,7 +124,7 @@ void main() {
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
       expect(await cache.get('key3'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
 
     test(
@@ -163,7 +163,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('key1');
       expect(await cache.get('key1'), isNull);
-      expect(cache.getKeys(), isNot(contains('key1')));
+      expect(await cache.getKeys(), isNot(contains('key1')));
     });
 
     test('remove() non-existent key is a no-op', () async {
@@ -171,8 +171,8 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('missing');
       // Use getKeys() — calling get() would consume the ephemeral entry
-      expect(cache.getKeys(), contains('key1'));
-      expect(cache.getKeys().length, equals(1));
+      expect(await cache.getKeys(), contains('key1'));
+      expect((await cache.getKeys()).length, equals(1));
     });
 
     test('remove() Future completes without error', () async {

--- a/test/caches/fifo_cache_test.dart
+++ b/test/caches/fifo_cache_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
 
     test('getKeys() works correctly (returns current keys)', () async {
@@ -34,11 +34,14 @@ void main() {
       await cache.set('key2', 'value2');
       await cache.set('key3', 'value3');
 
-      expect(cache.getKeys(), containsAll(['key1', 'key2', 'key3']));
+      expect(await cache.getKeys(), containsAll(['key1', 'key2', 'key3']));
 
       await cache.set('key4', 'value4'); // 'key1' will be removed
-      expect(cache.getKeys(), containsAll(['key2', 'key3', 'key4']));
-      expect(cache.getKeys(), isNot(contains('key1'))); // 'key1' is removed
+      expect(await cache.getKeys(), containsAll(['key2', 'key3', 'key4']));
+      expect(
+        await cache.getKeys(),
+        isNot(contains('key1')),
+      ); // 'key1' is removed
     });
 
     test('Cache string representation (testing toString())', () async {
@@ -101,8 +104,8 @@ void main() {
 
         await cache.set('B', 'newValueB'); // update existing key — no eviction
 
-        expect(cache.getKeys().length, equals(3));
-        expect(cache.getKeys(), containsAll(['A', 'B', 'C']));
+        expect((await cache.getKeys()).length, equals(3));
+        expect(await cache.getKeys(), containsAll(['A', 'B', 'C']));
         expect(await cache.get('B'), equals('newValueB'));
       },
     );
@@ -125,10 +128,10 @@ void main() {
       await Future.wait(futures);
 
       // Confirm that only 5 items remain in the cache
-      expect(cache.getKeys().length, equals(5));
+      expect((await cache.getKeys()).length, equals(5));
 
       // keys 0 to 4 should exist in the cache
-      final keys = cache.getKeys();
+      final keys = await cache.getKeys();
       expect(keys, containsAll([0, 1, 2, 3, 4]));
     });
 
@@ -144,7 +147,7 @@ void main() {
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
       expect(await cache.get('key3'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
   });
 
@@ -161,7 +164,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('key1');
       expect(await cache.get('key1'), isNull);
-      expect(cache.getKeys(), isNot(contains('key1')));
+      expect(await cache.getKeys(), isNot(contains('key1')));
     });
 
     test('remove() non-existent key is a no-op', () async {
@@ -169,7 +172,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('missing');
       expect(await cache.get('key1'), equals('value1'));
-      expect(cache.getKeys().length, equals(1));
+      expect((await cache.getKeys()).length, equals(1));
     });
 
     test('remove() Future completes without error', () async {

--- a/test/caches/lfu_cache_test.dart
+++ b/test/caches/lfu_cache_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
   });
 
@@ -71,7 +71,7 @@ void main() {
 
         expect(await cache.get('key1'), equals('new_value1'));
         expect(await cache.get('key2'), equals('value2'));
-        expect(cache.getKeys().length, equals(2));
+        expect((await cache.getKeys()).length, equals(2));
       },
     );
 
@@ -111,7 +111,7 @@ void main() {
 
       await Future.wait(futures);
       expect(
-        cache.getKeys().length,
+        (await cache.getKeys()).length,
         lessThanOrEqualTo(5),
       ); // Only 5 keys should remain
     });
@@ -127,7 +127,7 @@ void main() {
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
       expect(await cache.get('key3'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
   });
 
@@ -144,7 +144,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('key1');
       expect(await cache.get('key1'), isNull);
-      expect(cache.getKeys(), isNot(contains('key1')));
+      expect(await cache.getKeys(), isNot(contains('key1')));
     });
 
     test('remove() non-existent key is a no-op', () async {
@@ -152,7 +152,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('missing');
       expect(await cache.get('key1'), equals('value1'));
-      expect(cache.getKeys().length, equals(1));
+      expect((await cache.getKeys()).length, equals(1));
     });
 
     test('remove() Future completes without error', () async {

--- a/test/caches/lru_cache_test.dart
+++ b/test/caches/lru_cache_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
   });
 
@@ -88,10 +88,10 @@ void main() {
       await Future.wait(futures);
 
       // Ensure only 5 items remain in the cache
-      expect(cache.getKeys().length, equals(5));
+      expect((await cache.getKeys()).length, equals(5));
 
       // At least one key from 0 to 4 should be present in the cache
-      final keys = cache.getKeys();
+      final keys = await cache.getKeys();
       expect(keys, containsAll([0, 1, 2, 3, 4]));
     });
 
@@ -106,7 +106,7 @@ void main() {
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
       expect(await cache.get('key3'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
   });
 
@@ -123,7 +123,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('key1');
       expect(await cache.get('key1'), isNull);
-      expect(cache.getKeys(), isNot(contains('key1')));
+      expect(await cache.getKeys(), isNot(contains('key1')));
     });
 
     test('remove() non-existent key is a no-op', () async {
@@ -131,7 +131,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('missing');
       expect(await cache.get('key1'), equals('value1'));
-      expect(cache.getKeys().length, equals(1));
+      expect((await cache.getKeys()).length, equals(1));
     });
 
     test('remove() Future completes without error', () async {

--- a/test/caches/monitored_ephemeral_fifo_cache_test.dart
+++ b/test/caches/monitored_ephemeral_fifo_cache_test.dart
@@ -91,7 +91,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
 
     test('Should throw an exception if maxSize is 0 or negative', () {

--- a/test/caches/monitored_fifo_cache_test.dart
+++ b/test/caches/monitored_fifo_cache_test.dart
@@ -88,7 +88,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
 
     test('Should throw an exception if maxSize is 0 or negative', () {

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -95,7 +95,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
 
     test(
@@ -112,7 +112,7 @@ void main() {
 
         expect(await cache.get('key1'), equals('new_value1'));
         expect(await cache.get('key2'), equals('value2'));
-        expect(cache.getKeys().length, equals(2));
+        expect((await cache.getKeys()).length, equals(2));
       },
     );
 

--- a/test/caches/monitored_lru_cache_test.dart
+++ b/test/caches/monitored_lru_cache_test.dart
@@ -92,7 +92,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
 
     test('Should throw an exception if maxSize is 0 or negative', () {

--- a/test/caches/monitored_mru_cache_test.dart
+++ b/test/caches/monitored_mru_cache_test.dart
@@ -89,7 +89,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
 
     test('Should throw an exception if maxSize is 0 or negative', () {

--- a/test/caches/mru_cache_test.dart
+++ b/test/caches/mru_cache_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       expect(await cache.get('key1'), isNull);
       expect(await cache.get('key2'), isNull);
-      expect(cache.getKeys(), isEmpty);
+      expect(await cache.getKeys(), isEmpty);
     });
   });
 
@@ -59,8 +59,8 @@ void main() {
 
       await Future.wait(futures);
 
-      expect(cache.getKeys().length, equals(5));
-      expect(cache.getKeys(), containsAll([0, 1, 2, 3, 4]));
+      expect((await cache.getKeys()).length, equals(5));
+      expect(await cache.getKeys(), containsAll([0, 1, 2, 3, 4]));
     });
   });
 
@@ -77,7 +77,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('key1');
       expect(await cache.get('key1'), isNull);
-      expect(cache.getKeys(), isNot(contains('key1')));
+      expect(await cache.getKeys(), isNot(contains('key1')));
     });
 
     test('remove() non-existent key is a no-op', () async {
@@ -85,7 +85,7 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.remove('missing');
       expect(await cache.get('key1'), equals('value1'));
-      expect(cache.getKeys().length, equals(1));
+      expect((await cache.getKeys()).length, equals(1));
     });
 
     test('remove() Future completes without error', () async {

--- a/test/monitorings/cache_metrics_test.dart
+++ b/test/monitorings/cache_metrics_test.dart
@@ -148,13 +148,16 @@ void main() {
       );
     });
 
-    test('getRecentStats() with positive sub-millisecond Duration succeeds', () {
-      final metrics = CacheMetrics();
-      expect(
-        () => metrics.getRecentStats(const Duration(microseconds: 1)),
-        returnsNormally,
-      );
-    });
+    test(
+      'getRecentStats() with positive sub-millisecond Duration succeeds',
+      () {
+        final metrics = CacheMetrics();
+        expect(
+          () => metrics.getRecentStats(const Duration(microseconds: 1)),
+          returnsNormally,
+        );
+      },
+    );
 
     test('getRecentStats() with positive Duration succeeds', () {
       final metrics = CacheMetrics();

--- a/test/monitorings/cache_metrics_test.dart
+++ b/test/monitorings/cache_metrics_test.dart
@@ -131,6 +131,32 @@ void main() {
     });
   });
 
+  group('CacheMetrics - getRecentStats() validation', () {
+    test('getRecentStats(Duration.zero) throws ArgumentError', () {
+      final metrics = CacheMetrics();
+      expect(
+        () => metrics.getRecentStats(Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('getRecentStats() with negative Duration throws ArgumentError', () {
+      final metrics = CacheMetrics();
+      expect(
+        () => metrics.getRecentStats(const Duration(milliseconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('getRecentStats() with positive Duration succeeds', () {
+      final metrics = CacheMetrics();
+      expect(
+        () => metrics.getRecentStats(const Duration(minutes: 1)),
+        returnsNormally,
+      );
+    });
+  });
+
   group('CacheMetrics - Bounded Storage', () {
     test(
       '_latencies does not exceed maxLatencySamples entries after many recordHit calls',

--- a/test/monitorings/cache_metrics_test.dart
+++ b/test/monitorings/cache_metrics_test.dart
@@ -148,6 +148,14 @@ void main() {
       );
     });
 
+    test('getRecentStats() with positive sub-millisecond Duration succeeds', () {
+      final metrics = CacheMetrics();
+      expect(
+        () => metrics.getRecentStats(const Duration(microseconds: 1)),
+        returnsNormally,
+      );
+    });
+
     test('getRecentStats() with positive Duration succeeds', () {
       final metrics = CacheMetrics();
       expect(


### PR DESCRIPTION
## Summary

- **`CacheMetrics` Queue migration**: Replace `List<Duration>/_evictions` with `Queue<T>` so that rolling-window eviction uses `removeFirst()` (O(1)) instead of `removeAt(0)` (O(n)), eliminating repeated tail-shifts on high-frequency caches.
- **`getRecentStats()` ArgumentError guard**: Throw `ArgumentError` when `window.inMilliseconds <= 0` to prevent integer division crash (`~/ 0`). Consistent with the existing `maxSize <= 0` check in cache constructors.
- **`ThreadSafeCache.getKeys()` lock consistency**: Changed return type from `Iterable<K>` to `Future<Iterable<K>>` and wrapped all 10 ThreadSafeCache implementations in `_lock.synchronized()`, matching the lock pattern already used by `get`/`set`/`remove`/`clear`. Updated all affected test files to `await` the call.

## Test plan

- [x] `dart test` passes (all tests green, exit code 0)
- [x] New tests: `getRecentStats(Duration.zero)` throws `ArgumentError`
- [x] New tests: `getRecentStats` with negative `Duration` throws `ArgumentError`
- [x] Existing bounded-storage tests verify Queue rolling-window behaviour is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)