### PR TITLE
feat: add Disposable interface and lifecycle management to Monitored caches

### DIFF
--- a/lib/cacherine.dart
+++ b/lib/cacherine.dart
@@ -1,6 +1,7 @@
 library;
 
 // Interfaces
+export 'src/interfaces/disposable.dart';
 export 'src/interfaces/simple_cache.dart';
 export 'src/interfaces/thread_safe_cache.dart';
 

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -4,6 +4,7 @@ import 'package:synchronized/synchronized.dart';
 
 import '../monitorings/cache_alert_manager.dart';
 import '../monitorings/cache_monitoring.dart';
+import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
 /// **Thread-safe Ephemeral FIFO (First In, First Out) Cache with Monitoring**
@@ -27,7 +28,8 @@ import '../interfaces/thread_safe_cache.dart';
 /// - **The retrieved data cannot be reused (it is removed from the cache upon retrieval)**
 /// - **If you need to preserve the key, use `MonitoredFIFOCache` instead.**
 class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
-    with CacheMonitoring<K, V> {
+    with CacheMonitoring<K, V>
+    implements Disposable {
   final int maxSize;
   final LinkedHashMap<K, V> _cache = LinkedHashMap();
   final _lock = Lock();
@@ -124,6 +126,9 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
   }
+
+  @override
+  void dispose() => _cacheAlertManager.dispose();
 
   /// Returns a string representation of the current state of the cache.
   ///

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -4,6 +4,7 @@ import 'package:synchronized/synchronized.dart';
 
 import '../monitorings/cache_alert_manager.dart';
 import '../monitorings/cache_monitoring.dart';
+import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
 /// **Thread-safe FIFO (First In, First Out) Cache with Monitoring**
@@ -21,7 +22,8 @@ import '../interfaces/thread_safe_cache.dart';
 /// This cache implements the **FIFO eviction policy**, and:
 /// - When the cache size exceeds `maxSize`, the oldest element is removed.
 class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
-    with CacheMonitoring<K, V> {
+    with CacheMonitoring<K, V>
+    implements Disposable {
   final int maxSize;
   final LinkedHashMap<K, V> _cache = LinkedHashMap();
   final _lock = Lock();
@@ -129,6 +131,9 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
   }
+
+  @override
+  void dispose() => _cacheAlertManager.dispose();
 
   /// Returns a string representation of the current state of the cache.
   ///

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -3,6 +3,7 @@ import 'package:synchronized/synchronized.dart';
 
 import '../monitorings/cache_alert_manager.dart';
 import '../monitorings/cache_monitoring.dart';
+import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
 /// **Thread-safe LFU (Least Frequently Used) Cache with Monitoring**
@@ -20,7 +21,8 @@ import '../interfaces/thread_safe_cache.dart';
 /// This cache implements the **LFU eviction policy**, and:
 /// - When the cache size exceeds `maxSize`, the **least frequently used element is removed**.
 class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
-    with CacheMonitoring<K, V> {
+    with CacheMonitoring<K, V>
+    implements Disposable {
   final int maxSize;
   final LinkedHashMap<K, V> _cache = LinkedHashMap();
   final Map<K, int> _usageCounts = {};
@@ -150,6 +152,9 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
       _usageCounts.clear();
     });
   }
+
+  @override
+  void dispose() => _cacheAlertManager.dispose();
 
   /// Returns a string representation of the current state of the cache.
   ///

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -4,6 +4,7 @@ import 'package:synchronized/synchronized.dart';
 
 import '../monitorings/cache_alert_manager.dart';
 import '../monitorings/cache_monitoring.dart';
+import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
 /// **Thread-safe LRU (Least Recently Used) Cache with Monitoring**
@@ -21,7 +22,8 @@ import '../interfaces/thread_safe_cache.dart';
 /// This cache implements the **LRU eviction policy**, meaning:
 /// - When the cache size exceeds `maxSize`, the **least recently used element is removed**.
 class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
-    with CacheMonitoring<K, V> {
+    with CacheMonitoring<K, V>
+    implements Disposable {
   final int maxSize;
   final LinkedHashMap<K, V> _cache = LinkedHashMap();
   final _lock = Lock();
@@ -137,6 +139,9 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
   }
+
+  @override
+  void dispose() => _cacheAlertManager.dispose();
 
   /// Returns a string representation of the current state of the cache.
   ///

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -3,6 +3,7 @@ import 'package:synchronized/synchronized.dart';
 
 import '../monitorings/cache_alert_manager.dart';
 import '../monitorings/cache_monitoring.dart';
+import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
 /// **Thread-safe MRU (Most Recently Used) Cache with Monitoring**
@@ -20,7 +21,8 @@ import '../interfaces/thread_safe_cache.dart';
 /// Implements the **MRU eviction policy**, meaning:
 /// - When the cache size exceeds `maxSize`, the **most recently used element is removed**.
 class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
-    with CacheMonitoring<K, V> {
+    with CacheMonitoring<K, V>
+    implements Disposable {
   final int maxSize;
   final LinkedHashMap<K, V> _cache = LinkedHashMap();
   final _lock = Lock();
@@ -145,6 +147,9 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
   }
+
+  @override
+  void dispose() => _cacheAlertManager.dispose();
 
   /// Returns a string representation of the current state of the cache.
   ///

--- a/lib/src/interfaces/disposable.dart
+++ b/lib/src/interfaces/disposable.dart
@@ -1,0 +1,3 @@
+abstract interface class Disposable {
+  void dispose();
+}

--- a/lib/src/interfaces/disposable.dart
+++ b/lib/src/interfaces/disposable.dart
@@ -1,3 +1,32 @@
+/// **Disposable Interface**
+///
+/// Defines a **lifecycle contract for objects that hold resources requiring explicit cleanup**.
+/// - Implemented by all `Monitored*` cache classes (`MonitoredLRUCache`, `MonitoredMRUCache`,
+///   `MonitoredFIFOCache`, `MonitoredLFUCache`, `MonitoredEphemeralFIFOCache`), each of which
+///   starts an internal `Timer.periodic` that must be cancelled to prevent resource leaks.
+/// - Calling `dispose()` cancels the alert-monitoring timer and releases all references held
+///   by the cache's `CacheAlertManager`.
+/// - **`dispose()` is idempotent**: calling it more than once is safe and has no effect.
+/// - After `dispose()` is called, cache read/write operations (`get()`, `set()`, etc.) continue
+///   to function, but alert monitoring stops.
+///
+/// **Usage pattern:**
+/// ```dart
+/// final cache = MonitoredLRUCache<String, String>(
+///   maxSize: 100,
+///   alertConfig: CacheAlertConfig(notifyCallback: print),
+/// );
+/// // ... use the cache ...
+/// cache.dispose(); // cancel the internal timer when done
+/// ```
+///
+/// **Type-check pattern (when holding a `ThreadSafeCache` reference):**
+/// ```dart
+/// if (cache is Disposable) cache.dispose();
+/// ```
 abstract interface class Disposable {
+  /// **Cancels any resources held by this object.**
+  ///
+  /// - Safe to call multiple times (idempotent).
   void dispose();
 }

--- a/lib/src/monitorings/cache_alert_manager.dart
+++ b/lib/src/monitorings/cache_alert_manager.dart
@@ -10,6 +10,9 @@ class CacheAlertManager {
   final CacheMetrics metrics;
   final CacheAlertConfig config;
 
+  Timer? _timer;
+  bool _isDisposed = false;
+
   /// Initializes the alert manager.
   /// [metrics] is an instance of [CacheMetrics] that tracks cache performance,
   /// and [config] is an instance of [CacheAlertConfig] that configures the alert thresholds and notifications.
@@ -17,10 +20,19 @@ class CacheAlertManager {
 
   /// Periodically monitors cache performance at the interval specified in [config].
   void monitor() {
-    Timer.periodic(config.alertCheckInterval, (_) {
+    if (_isDisposed) return;
+    _timer?.cancel();
+    _timer = Timer.periodic(config.alertCheckInterval, (_) {
       final stats = metrics.getRecentStats(config.alertCheckInterval);
       _checkAlerts(stats);
     });
+  }
+
+  /// Cancels the monitoring timer and releases resources.
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+    _isDisposed = true;
   }
 
   /// Checks the cache statistics and triggers alerts if any thresholds are exceeded.

--- a/test/caches/monitored_ephemeral_fifo_cache_test.dart
+++ b/test/caches/monitored_ephemeral_fifo_cache_test.dart
@@ -129,5 +129,14 @@ void main() {
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
     });
+
+    test('dispose() implements Disposable and stops the timer', () {
+      final cache = MonitoredEphemeralFIFOCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      expect(cache, isA<Disposable>());
+      expect(cache.dispose, returnsNormally);
+    });
   });
 }

--- a/test/caches/monitored_fifo_cache_test.dart
+++ b/test/caches/monitored_fifo_cache_test.dart
@@ -124,5 +124,14 @@ void main() {
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
     });
+
+    test('dispose() implements Disposable and stops the timer', () {
+      final cache = MonitoredFIFOCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      expect(cache, isA<Disposable>());
+      expect(cache.dispose, returnsNormally);
+    });
   });
 }

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -172,5 +172,14 @@ void main() {
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
     });
+
+    test('dispose() implements Disposable and stops the timer', () {
+      final cache = MonitoredLFUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      expect(cache, isA<Disposable>());
+      expect(cache.dispose, returnsNormally);
+    });
   });
 }

--- a/test/caches/monitored_mru_cache_test.dart
+++ b/test/caches/monitored_mru_cache_test.dart
@@ -125,5 +125,14 @@ void main() {
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
     });
+
+    test('dispose() implements Disposable and stops the timer', () {
+      final cache = MonitoredMRUCache<String, String>(
+        maxSize: 3,
+        alertConfig: config,
+      );
+      expect(cache, isA<Disposable>());
+      expect(cache.dispose, returnsNormally);
+    });
   });
 }

--- a/test/monitorings/cache_alert_manager_test.dart
+++ b/test/monitorings/cache_alert_manager_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
-import 'package:cacherine/src/monitorings/cache_alert_manager.dart';
-import 'package:cacherine/src/monitorings/cache_metrics.dart';
+import 'package:cacherine/cacherine.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -188,6 +187,89 @@ void main() {
         receivedAlerts.length,
         greaterThanOrEqualTo(2),
       ); // At least two alerts triggered
+      alertManager.dispose();
+    });
+  });
+
+  group('CacheAlertManager - Lifecycle', () {
+    late CacheMetrics metrics;
+    late List<String> receivedAlerts;
+    late CacheAlertManager alertManager;
+
+    setUp(() {
+      metrics = CacheMetrics();
+      receivedAlerts = [];
+      final config = CacheAlertConfig(
+        notifyCallback: (alert) => receivedAlerts.add(alert),
+        hitRateThreshold: 0.5,
+        alertCheckInterval: const Duration(milliseconds: 50),
+      );
+      alertManager = CacheAlertManager(metrics, config);
+    });
+
+    test('dispose stops the timer', () async {
+      // Record misses so alerts would fire if timer is active
+      for (int i = 0; i < 10; i++) {
+        metrics.recordMiss(Duration.zero);
+      }
+      alertManager.monitor();
+      await Future.delayed(const Duration(milliseconds: 100));
+      final countBeforeDispose = receivedAlerts.length;
+      expect(countBeforeDispose, greaterThan(0));
+
+      alertManager.dispose();
+      receivedAlerts.clear();
+
+      // Wait past several check intervals — no new alerts should fire
+      await Future.delayed(const Duration(milliseconds: 200));
+      expect(receivedAlerts, isEmpty);
+    });
+
+    test('dispose is idempotent', () {
+      alertManager.monitor();
+      expect(() {
+        alertManager.dispose();
+        alertManager.dispose();
+      }, returnsNormally);
+    });
+
+    test('monitor called twice does not double-fire', () async {
+      for (int i = 0; i < 10; i++) {
+        metrics.recordMiss(Duration.zero);
+      }
+      alertManager.monitor();
+      alertManager.monitor(); // second call cancels the first timer
+
+      await Future.delayed(const Duration(milliseconds: 200));
+
+      // With a single timer firing every 50ms over 200ms we expect ~4 firings.
+      // If timers were doubled we would see significantly more.
+      expect(receivedAlerts.length, lessThan(10));
+      alertManager.dispose();
+    });
+
+    test('monitor after dispose is a no-op', () async {
+      alertManager.monitor();
+      alertManager.dispose();
+      receivedAlerts.clear();
+
+      alertManager.monitor(); // should be a no-op
+      await Future.delayed(const Duration(milliseconds: 200));
+      expect(receivedAlerts, isEmpty);
+    });
+  });
+
+  group('Disposable type check', () {
+    test('MonitoredLRUCache implements Disposable', () {
+      final cache = MonitoredLRUCache<String, String>(
+        maxSize: 10,
+        alertConfig: CacheAlertConfig(
+          notifyCallback: (_) {},
+          alertCheckInterval: const Duration(seconds: 60),
+        ),
+      );
+      expect(cache, isA<Disposable>());
+      cache.dispose();
     });
   });
 }

--- a/test/monitorings/cache_alert_manager_test.dart
+++ b/test/monitorings/cache_alert_manager_test.dart
@@ -28,6 +28,8 @@ void main() {
       alertManager = CacheAlertManager(metrics, config);
     });
 
+    tearDown(() => alertManager.dispose());
+
     test('Triggers alert when hit rate is too low', () async {
       // 90% of requests are misses
       for (int i = 0; i < 10; i++) {
@@ -206,6 +208,8 @@ void main() {
       );
       alertManager = CacheAlertManager(metrics, config);
     });
+
+    tearDown(() => alertManager.dispose());
 
     test('dispose stops the timer', () async {
       // Record misses so alerts would fire if timer is active


### PR DESCRIPTION
## Summary

- `Monitored*` caches started a `Timer.periodic` in their constructor but provided no way to stop it, causing resource leaks when instances were discarded (Flutter widget disposal, long-running service cache replacement, etc.)
- Add `abstract interface class Disposable` (`void dispose()`) to `lib/src/interfaces/` and export it from `lib/cacherine.dart`
- `CacheAlertManager` now stores its `Timer` internally, exposes `dispose()`, and guards against double-dispose and post-dispose `monitor()` calls via `_isDisposed`
- All five `Monitored*` cache classes (`LRU`, `MRU`, `FIFO`, `LFU`, `EphemeralFIFO`) implement `Disposable` and delegate to `_cacheAlertManager.dispose()`
- No breaking changes — `dispose()` is additive; `ThreadSafeCache` interface is untouched

## Test plan

- [x] `dispose()` stops the timer — no callbacks fire after dispose even past multiple check intervals
- [x] `dispose()` is idempotent — calling twice throws no exception
- [x] `monitor()` called twice cancels the first timer before starting the second (no double-firing)
- [x] `monitor()` after `dispose()` is a no-op — no new timer is created
- [x] `MonitoredLRUCache` satisfies `isA<Disposable>()` type check
- [x] All existing tests pass (`dart test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)