### PR TITLE
fix: align MonitoredCache eviction tracking and LFU set() counter with docs

### DIFF
--- a/doc/lfu_cache.md
+++ b/doc/lfu_cache.md
@@ -38,6 +38,7 @@ The LFU Cache eviction policy follows these rules:
 1. If the key exists:
    - Update the value.
    - Increment the frequency counter.
+     (The key is treated as accessed, so its frequency increases.)
 2. If the key does not exist:
    - If the cache exceeds the [maxSize], evict entries based on LFU policy.
    - Add the new key-value pair and initialize the frequency counter to 1.
@@ -47,14 +48,14 @@ The LFU Cache eviction policy follows these rules:
 1. Initial state: LFUCache<maxCount: 3>
 
    - The cache is empty.
-     | index | Key | Frequency Count |
+     | Order | Key | Frequency Count |
      | ----- | --- | --------------- |
      | 0 | - | - |
 
 2. set A
 
    - Key A is added to the cache. The frequency count is 1 on the first insertion.
-     | index | Key | Frequency Count |
+     | Order | Key | Frequency Count |
      |-------|-----|-----------------|
      | 0 | A | 1 |
 
@@ -88,9 +89,9 @@ The LFU Cache eviction policy follows these rules:
    - A new key D is added, requiring space in the cache (maxSize: 3). B and C have the same frequency of 1, but B is evicted because it was inserted first.
      | Order | Key | Frequency Count |
      |-------|-----|-----------------|
-     | 1 | A | 2 |
-     | 3 | C | 1 |
-     | 4 | D | 1 |
+     | 0 | A | 2 |
+     | 2 | C | 1 |
+     | 3 | D | 1 |
 
 ## 4. Suitable Use Cases
 

--- a/doc/lru_cache.md
+++ b/doc/lru_cache.md
@@ -86,7 +86,7 @@ The eviction policy of an LRU Cache follows these rules:
    - Add a new key D. Since the cache has reached maxSize (3), B, being the least recently used, is evicted.
      | Order | Key | Value |
      | ----- | --- | ----- |
-     | 2 | A | ... |
+     | 3 | A | ... |
      | 4 | C | ... |
      | 5 | D | ... |
 

--- a/doc/mru_cache.md
+++ b/doc/mru_cache.md
@@ -81,7 +81,7 @@ The eviction policy of MRU Cache follows these rules:
      | 3 | A |
      | 4 | C |
 
-6. set D (A evicted due to MRU)
+6. set D (C evicted due to MRU)
 
    - Add key D. Since the cache has reached its max size (maxSize: 3), C, being the most recently accessed, is evicted.
      | Order | Key | Value |

--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -67,6 +67,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
     await _lock.synchronized(() {
       if (_cache.containsKey(key)) {
         _cache[key] = value;
+        _usageCounts[key] = (_usageCounts[key] ?? 0) + 1;
         return;
       }
       if (_cache.length >= maxSize) {

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -92,10 +92,11 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
-      if (_cache.length >= maxSize) {
+      if (!_cache.containsKey(key) && _cache.length >= maxSize) {
         _cache.remove(
           _cache.keys.first,
         ); // Remove the oldest element based on FIFO policy
+        metrics.recordEviction();
       }
       _cache[key] = value; // Update value (position remains unchanged)
     });

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -97,10 +97,11 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
-      if (_cache.length >= maxSize) {
+      if (!_cache.containsKey(key) && _cache.length >= maxSize) {
         _cache.remove(
           _cache.keys.first,
         ); // Remove the oldest element based on FIFO policy
+        metrics.recordEviction();
       }
       _cache[key] = value; // Update value (position remains unchanged)
     });

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -101,10 +101,12 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
     await _lock.synchronized(() {
       if (_cache.containsKey(key)) {
         _cache[key] = value;
+        _usageCounts[key] = (_usageCounts[key] ?? 0) + 1;
         return;
       }
       if (_cache.length >= maxSize) {
         _evictLFUEntry();
+        metrics.recordEviction();
       }
       _cache[key] = value;
       _usageCounts[key] = 1;

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -109,6 +109,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
         _cache.remove(
           _cache.keys.first,
         ); // Remove the least recently used element
+        metrics.recordEviction();
       }
       _cache[key] = value;
     });

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -107,6 +107,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
         _cache.remove(key);
       } else if (_cache.length >= maxSize) {
         _evictMRUEntry(); // Perform eviction using MRU policy
+        metrics.recordEviction();
       }
       // Insert the key to mark it as the most recently used
       _cache[key] = value;

--- a/test/caches/lfu_cache_test.dart
+++ b/test/caches/lfu_cache_test.dart
@@ -75,19 +75,19 @@ void main() {
       },
     );
 
-    test('set() on an existing key preserves its usage count', () async {
+    test('set() on an existing key increments its usage count', () async {
       final cache = LFUCache<String, String>(2);
       await cache.set('key1', 'value1');
       await cache.set('key2', 'value2');
 
-      // Boost key1's usage count
+      // Boost key1's usage count via get (count = 3)
       await cache.get('key1');
       await cache.get('key1');
 
-      // Update key1 — count must be preserved, not reset to 1
+      // Update key1 via set — count increments (not reset to 1)
       await cache.set('key1', 'updated');
 
-      // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+      // Inserting key3 forces eviction; key2 (count 1) must go, not key1
       await cache.set('key3', 'value3');
 
       expect(await cache.get('key2'), isNull);

--- a/test/caches/monitored_ephemeral_fifo_cache_test.dart
+++ b/test/caches/monitored_ephemeral_fifo_cache_test.dart
@@ -104,9 +104,12 @@ void main() {
         await cache.set('key1', 'value1');
         await cache.set('key2', 'value2');
 
-        await cache.set('key1', 'new_value1');
+        // Update the non-oldest key (key2). With the buggy implementation that
+        // lacked the containsKey guard, key1 (oldest) would be evicted here.
+        await cache.set('key2', 'new_value2');
 
         expect((await cache.getKeys()).length, equals(2));
+        expect(await cache.get('key1'), equals('value1'));
       },
     );
 

--- a/test/caches/monitored_ephemeral_fifo_cache_test.dart
+++ b/test/caches/monitored_ephemeral_fifo_cache_test.dart
@@ -94,6 +94,22 @@ void main() {
       expect(await cache.getKeys(), isEmpty);
     });
 
+    test(
+      'set() on an existing key when cache is full does not evict any entry',
+      () async {
+        final cache = MonitoredEphemeralFIFOCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        await cache.set('key1', 'new_value1');
+
+        expect((await cache.getKeys()).length, equals(2));
+      },
+    );
+
     test('Should throw an exception if maxSize is 0 or negative', () {
       expect(
         () => MonitoredEphemeralFIFOCache<String, String>(
@@ -128,6 +144,18 @@ void main() {
       await cache.remove('missing');
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
+    });
+
+    test('capacity eviction via set() records eviction in metrics', () async {
+      final cache = MonitoredEphemeralFIFOCache<String, String>(
+        maxSize: 2,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.set('key2', 'value2');
+      await cache.set('key3', 'value3'); // triggers FIFO eviction of key1
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
     });
 
     test('dispose() implements Disposable and stops the timer', () {

--- a/test/caches/monitored_fifo_cache_test.dart
+++ b/test/caches/monitored_fifo_cache_test.dart
@@ -101,10 +101,12 @@ void main() {
         await cache.set('key1', 'value1');
         await cache.set('key2', 'value2');
 
-        await cache.set('key1', 'new_value1');
+        // Update the non-oldest key (key2). With the buggy implementation that
+        // lacked the containsKey guard, key1 (oldest) would be evicted here.
+        await cache.set('key2', 'new_value2');
 
-        expect(await cache.get('key1'), equals('new_value1'));
-        expect(await cache.get('key2'), equals('value2'));
+        expect(await cache.get('key1'), equals('value1'));
+        expect(await cache.get('key2'), equals('new_value2'));
         expect((await cache.getKeys()).length, equals(2));
       },
     );

--- a/test/caches/monitored_fifo_cache_test.dart
+++ b/test/caches/monitored_fifo_cache_test.dart
@@ -91,6 +91,24 @@ void main() {
       expect(await cache.getKeys(), isEmpty);
     });
 
+    test(
+      'set() on an existing key when cache is full does not evict any entry',
+      () async {
+        final cache = MonitoredFIFOCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        await cache.set('key1', 'new_value1');
+
+        expect(await cache.get('key1'), equals('new_value1'));
+        expect(await cache.get('key2'), equals('value2'));
+        expect((await cache.getKeys()).length, equals(2));
+      },
+    );
+
     test('Should throw an exception if maxSize is 0 or negative', () {
       expect(
         () =>
@@ -123,6 +141,18 @@ void main() {
       await cache.remove('missing');
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
+    });
+
+    test('capacity eviction via set() records eviction in metrics', () async {
+      final cache = MonitoredFIFOCache<String, String>(
+        maxSize: 2,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.set('key2', 'value2');
+      await cache.set('key3', 'value3'); // triggers FIFO eviction of key1
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
     });
 
     test('dispose() implements Disposable and stops the timer', () {

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -116,7 +116,7 @@ void main() {
       },
     );
 
-    test('set() on an existing key preserves its usage count', () async {
+    test('set() on an existing key increments its usage count', () async {
       final cache = MonitoredLFUCache<String, String>(
         maxSize: 2,
         alertConfig: config,
@@ -124,14 +124,14 @@ void main() {
       await cache.set('key1', 'value1');
       await cache.set('key2', 'value2');
 
-      // Boost key1's usage count
+      // Boost key1's usage count via get (count = 3)
       await cache.get('key1');
       await cache.get('key1');
 
-      // Update key1 — count must be preserved, not reset to 1
+      // Update key1 via set — count increments (not reset to 1)
       await cache.set('key1', 'updated');
 
-      // Inserting key3 forces eviction; key2 (count 1) must go, not key1 (count 3)
+      // Inserting key3 forces eviction; key2 (count 1) must go, not key1
       await cache.set('key3', 'value3');
 
       expect(await cache.get('key2'), isNull);
@@ -171,6 +171,21 @@ void main() {
       await cache.remove('missing');
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
+    });
+
+    test('capacity eviction via set() records eviction in metrics', () async {
+      final cache = MonitoredLFUCache<String, String>(
+        maxSize: 2,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.set('key2', 'value2');
+      await cache.set(
+        'key3',
+        'value3',
+      ); // triggers LFU eviction of key1 or key2
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
     });
 
     test('dispose() implements Disposable and stops the timer', () {

--- a/test/caches/monitored_lru_cache_test.dart
+++ b/test/caches/monitored_lru_cache_test.dart
@@ -128,5 +128,17 @@ void main() {
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(0));
     });
+
+    test('capacity eviction via set() records eviction in metrics', () async {
+      final cache = MonitoredLRUCache<String, String>(
+        maxSize: 2,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.set('key2', 'value2');
+      await cache.set('key3', 'value3'); // triggers LRU eviction of key1
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
+    });
   });
 }

--- a/test/caches/monitored_mru_cache_test.dart
+++ b/test/caches/monitored_mru_cache_test.dart
@@ -126,6 +126,18 @@ void main() {
       expect(stats['evictions_per_minute'], equals(0));
     });
 
+    test('capacity eviction via set() records eviction in metrics', () async {
+      final cache = MonitoredMRUCache<String, String>(
+        maxSize: 2,
+        alertConfig: config,
+      );
+      await cache.set('key1', 'value1');
+      await cache.set('key2', 'value2');
+      await cache.set('key3', 'value3'); // triggers MRU eviction of key2
+      final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
+      expect(stats['evictions_per_minute'], equals(1));
+    });
+
     test('dispose() implements Disposable and stops the timer', () {
       final cache = MonitoredMRUCache<String, String>(
         maxSize: 3,


### PR DESCRIPTION
## Summary

Discovered and fixed three categories of discrepancies between `doc/` documentation and the actual implementation:

**Implementation fixes (behaviour was wrong):**
- `MonitoredFIFOCache` / `MonitoredEphemeralFIFOCache`: `set()` was missing the `!containsKey` guard, causing a spurious eviction when updating an existing key on a full cache. Non-monitored variants had the correct guard.
- All Monitored caches: `metrics.recordEviction()` was only called from `remove()` (manual deletion). Capacity-triggered evictions inside `set()` were silently not recorded, making the eviction metric in `CacheAlertManager` effectively useless.
- `LFUCache` / `MonitoredLFUCache`: `set()` on an existing key did not increment the usage counter, contradicting both the documentation and standard LFU semantics.

**Documentation fixes (text was wrong):**
- `doc/lfu_cache.md`: unified column header (`index` → `Order`), corrected step-6 order numbers, clarified that `set()` increments the frequency counter.
- `doc/mru_cache.md`: fixed step-6 heading ("A evicted" → "C evicted").
- `doc/lru_cache.md`: fixed step-6 order value for key A (2 → 3).

## Test plan

- [x] `fvm dart test` — all 202 tests pass
- [x] New tests added: `capacity eviction via set() records eviction in metrics` for every Monitored cache type
- [x] New tests added: `set() on an existing key when full does not evict any entry` for FIFO Monitored variants
- [x] Renamed: LFU `"preserves usage count"` → `"increments usage count"` to match new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)