### PR TITLE
fix: LFUCache.set() on existing key must not increment usage count

### DIFF
--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -67,7 +67,6 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
     await _lock.synchronized(() {
       if (_cache.containsKey(key)) {
         _cache[key] = value;
-        _usageCounts[key] = (_usageCounts[key] ?? 0) + 1;
         return;
       }
       if (_cache.length >= maxSize) {

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -101,7 +101,6 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
     await _lock.synchronized(() {
       if (_cache.containsKey(key)) {
         _cache[key] = value;
-        _usageCounts[key] = (_usageCounts[key] ?? 0) + 1;
         return;
       }
       if (_cache.length >= maxSize) {

--- a/test/caches/lfu_cache_test.dart
+++ b/test/caches/lfu_cache_test.dart
@@ -75,24 +75,54 @@ void main() {
       },
     );
 
-    test('set() on an existing key increments its usage count', () async {
+    test(
+      'set() on an existing key preserves its usage count (not reset to 1)',
+      () async {
+        final cache = LFUCache<String, String>(2);
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        // Boost key1's usage count via get (count = 3)
+        await cache.get('key1');
+        await cache.get('key1');
+
+        // Update key1 via set — count is preserved, not reset to 1
+        await cache.set('key1', 'updated');
+
+        // Inserting key3 forces eviction; key2 (count 1) must go, not key1
+        await cache.set('key3', 'value3');
+
+        expect(await cache.get('key2'), isNull);
+        expect(await cache.get('key1'), equals('updated'));
+        expect(await cache.get('key3'), equals('value3'));
+      },
+    );
+
+    test('set() on an existing key does not inflate its usage count', () async {
+      // Regression: repeated set() calls must not increment the usage count.
+      // If they did, the count could exceed that of a key boosted via get(),
+      // causing the wrong key to be evicted.
       final cache = LFUCache<String, String>(2);
-      await cache.set('key1', 'value1');
-      await cache.set('key2', 'value2');
+      await cache.set('keyA', 'valueA');
+      await cache.set('keyB', 'valueB');
 
-      // Boost key1's usage count via get (count = 3)
-      await cache.get('key1');
-      await cache.get('key1');
+      // Boost keyA's count to 4 via three get() calls (1 initial + 3 gets)
+      await cache.get('keyA');
+      await cache.get('keyA');
+      await cache.get('keyA');
 
-      // Update key1 via set — count increments (not reset to 1)
-      await cache.set('key1', 'updated');
+      // Update keyB four times via set(); count must remain 1
+      await cache.set('keyB', 'update1');
+      await cache.set('keyB', 'update2');
+      await cache.set('keyB', 'update3');
+      await cache.set('keyB', 'update4');
 
-      // Inserting key3 forces eviction; key2 (count 1) must go, not key1
-      await cache.set('key3', 'value3');
+      // Insert keyC — eviction must remove keyB (count 1), not keyA (count 4)
+      await cache.set('keyC', 'valueC');
 
-      expect(await cache.get('key2'), isNull);
-      expect(await cache.get('key1'), equals('updated'));
-      expect(await cache.get('key3'), equals('value3'));
+      expect(await cache.get('keyB'), isNull);
+      expect(await cache.get('keyA'), equals('valueA'));
+      expect(await cache.get('keyC'), equals('valueC'));
     });
   });
 

--- a/test/caches/lfu_cache_test.dart
+++ b/test/caches/lfu_cache_test.dart
@@ -82,14 +82,21 @@ void main() {
         await cache.set('key1', 'value1');
         await cache.set('key2', 'value2');
 
-        // Boost key1's usage count via get (count = 3)
+        // Give key2 count=2 so a reset-to-1 on key1 would make key1 the LFU
+        await cache.get('key2');
+
+        // Boost key1's count to 5
+        await cache.get('key1');
+        await cache.get('key1');
         await cache.get('key1');
         await cache.get('key1');
 
-        // Update key1 via set — count is preserved, not reset to 1
+        // Update key1 via set — count must be preserved at 5, not reset to 1.
+        // If reset to 1, key1 (count 1) < key2 (count 2) → key1 would be
+        // evicted instead of key2, and the assertions below would fail.
         await cache.set('key1', 'updated');
 
-        // Inserting key3 forces eviction; key2 (count 1) must go, not key1
+        // Inserting key3 forces eviction; key2 (count 2) must go, not key1
         await cache.set('key3', 'value3');
 
         expect(await cache.get('key2'), isNull);

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -126,14 +126,21 @@ void main() {
         await cache.set('key1', 'value1');
         await cache.set('key2', 'value2');
 
-        // Boost key1's usage count via get (count = 3)
+        // Give key2 count=2 so a reset-to-1 on key1 would make key1 the LFU
+        await cache.get('key2');
+
+        // Boost key1's count to 5
+        await cache.get('key1');
+        await cache.get('key1');
         await cache.get('key1');
         await cache.get('key1');
 
-        // Update key1 via set — count is preserved, not reset to 1
+        // Update key1 via set — count must be preserved at 5, not reset to 1.
+        // If reset to 1, key1 (count 1) < key2 (count 2) → key1 would be
+        // evicted instead of key2, and the assertions below would fail.
         await cache.set('key1', 'updated');
 
-        // Inserting key3 forces eviction; key2 (count 1) must go, not key1
+        // Inserting key3 forces eviction; key2 (count 2) must go, not key1
         await cache.set('key3', 'value3');
 
         expect(await cache.get('key2'), isNull);

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -116,27 +116,58 @@ void main() {
       },
     );
 
-    test('set() on an existing key increments its usage count', () async {
+    test(
+      'set() on an existing key preserves its usage count (not reset to 1)',
+      () async {
+        final cache = MonitoredLFUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+
+        // Boost key1's usage count via get (count = 3)
+        await cache.get('key1');
+        await cache.get('key1');
+
+        // Update key1 via set — count is preserved, not reset to 1
+        await cache.set('key1', 'updated');
+
+        // Inserting key3 forces eviction; key2 (count 1) must go, not key1
+        await cache.set('key3', 'value3');
+
+        expect(await cache.get('key2'), isNull);
+        expect(await cache.get('key1'), equals('updated'));
+        expect(await cache.get('key3'), equals('value3'));
+      },
+    );
+
+    test('set() on an existing key does not inflate its usage count', () async {
+      // Regression: repeated set() calls must not increment the usage count.
       final cache = MonitoredLFUCache<String, String>(
         maxSize: 2,
         alertConfig: config,
       );
-      await cache.set('key1', 'value1');
-      await cache.set('key2', 'value2');
+      await cache.set('keyA', 'valueA');
+      await cache.set('keyB', 'valueB');
 
-      // Boost key1's usage count via get (count = 3)
-      await cache.get('key1');
-      await cache.get('key1');
+      // Boost keyA's count to 4 via three get() calls (1 initial + 3 gets)
+      await cache.get('keyA');
+      await cache.get('keyA');
+      await cache.get('keyA');
 
-      // Update key1 via set — count increments (not reset to 1)
-      await cache.set('key1', 'updated');
+      // Update keyB four times via set(); count must remain 1
+      await cache.set('keyB', 'update1');
+      await cache.set('keyB', 'update2');
+      await cache.set('keyB', 'update3');
+      await cache.set('keyB', 'update4');
 
-      // Inserting key3 forces eviction; key2 (count 1) must go, not key1
-      await cache.set('key3', 'value3');
+      // Insert keyC — eviction must remove keyB (count 1), not keyA (count 4)
+      await cache.set('keyC', 'valueC');
 
-      expect(await cache.get('key2'), isNull);
-      expect(await cache.get('key1'), equals('updated'));
-      expect(await cache.get('key3'), equals('value3'));
+      expect(await cache.get('keyB'), isNull);
+      expect(await cache.get('keyA'), equals('valueA'));
+      expect(await cache.get('keyC'), equals('valueC'));
     });
 
     test('Should throw an exception if maxSize is 0 or negative', () {

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -123,6 +123,7 @@ void main() {
           maxSize: 2,
           alertConfig: config,
         );
+        addTearDown(cache.dispose);
         await cache.set('key1', 'value1');
         await cache.set('key2', 'value2');
 
@@ -155,6 +156,7 @@ void main() {
         maxSize: 2,
         alertConfig: config,
       );
+      addTearDown(cache.dispose);
       await cache.set('keyA', 'valueA');
       await cache.set('keyB', 'valueB');
 


### PR DESCRIPTION
## Summary

- `LFUCache.set()` and `MonitoredLFUCache.set()` were incrementing `_usageCounts` when called on an existing key, making the key artificially harder to evict than the LFU policy requires
- Removed the erroneous `_usageCounts[key] = (_usageCounts[key] ?? 0) + 1` line from the existing-key branch of `set()` in both classes (`SimpleLFUCache` was already correct)
- Added regression tests in `lfu_cache_test.dart` and `monitored_lfu_cache_test.dart` that specifically catch the off-by-one: boost one key's count via `get()`, repeatedly call `set()` on another key, then verify the `set()`-updated key (count = 1) is evicted — not the `get()`-boosted key

## Test plan

- [x] `dart test` passes with all existing tests green
- [x] New test `set() on an existing key does not inflate its usage count` fails against the unfixed code and passes after the fix
- [x] Existing test renamed from "increments its usage count" → "preserves its usage count (not reset to 1)" to accurately reflect the specified behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)