### PR TITLE
feat: release v2.0.0 — CacheStatsDashboard, TTLCache, and Lifecycle Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.2.0 - CacheStatsDashboard
+
+### New Features
+
+- **CacheStatsDashboard**: New class that wraps `CacheMetrics` to produce typed `DashboardSnapshot` objects for terminal-ready metric display.
+- **DashboardSnapshot**: Immutable value type capturing `hitRate`, `missRate`, latency percentiles (`p50`, `p95`, `p99`), `evictionsPerMinute`, `totalRequests`, and `capturedAt`.
+- **formatDashboard()**: New top-level function that renders a `DashboardSnapshot` as a Unicode box-drawing terminal panel.
+
+### Breaking Changes
+
+- `CacheStatsDashboard.snapshot(Duration window)` now throws `ArgumentError` for zero or negative `window` values (previously undefined behaviour propagated from `CacheMetrics.getRecentStats`).
+- `CacheStatsDashboard.stream(Duration window, Duration interval)` now throws `ArgumentError` for zero or negative `interval` values.
+
 ## 1.1.5 - Bug Fixes
 
 - Fixed spurious eviction in FIFO `set()` when updating an existing key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
-## 1.2.0 - CacheStatsDashboard
+## 1.2.0 - CacheStatsDashboard, TTLCache, and Lifecycle Management
 
 ### New Features
 
 - **CacheStatsDashboard**: New class that wraps `CacheMetrics` to produce typed `DashboardSnapshot` objects for terminal-ready metric display.
+- **TTLCache**: Added a standalone cache implementation supporting Time-To-Live (TTL) for both global and per-entry expiry.
+- **Disposable Interface**: Introduced a standard `Disposable` interface to handle resource cleanup (timers, controllers) across monitored and TTL caches.
 - **DashboardSnapshot**: Immutable value type capturing `hitRate`, `missRate`, latency percentiles (`p50`, `p95`, `p99`), `evictionsPerMinute`, `totalRequests`, and `capturedAt`.
-- **formatDashboard()**: New top-level function that renders a `DashboardSnapshot` as a Unicode box-drawing terminal panel.
+- **formatDashboard()**: New top-level function that renders a `DashboardSnapshot` as a Unicode box-drawing terminal panel with adaptive unit formatting (µs, ms, s).
 
 ### Breaking Changes
 
+- **Interface Implementation**: All `Monitored*` caches and `TTLCache` now implement `Disposable`. Callers managing these instances should call `.dispose()` to prevent timer leaks.
 - `CacheStatsDashboard.snapshot(Duration window)` now throws `ArgumentError` for zero or negative `window` values (previously undefined behaviour propagated from `CacheMetrics.getRecentStats`).
 - `CacheStatsDashboard.stream(Duration window, Duration interval)` now throws `ArgumentError` for zero or negative `interval` values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0 - CacheStatsDashboard, TTLCache, and Lifecycle Management
+## 2.0.0 - CacheStatsDashboard, TTLCache, and Lifecycle Management
 
 ### New Features
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cacherine
 description: A Dart library offering flexible in-memory cache implementations (FIFO, LRU, MRU, LFU) with both single-threaded and async options for concurrent environments.
-version: 1.2.0
+version: 2.0.0
 repository: https://github.com/yordgenome03/cacherine
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cacherine
 description: A Dart library offering flexible in-memory cache implementations (FIFO, LRU, MRU, LFU) with both single-threaded and async options for concurrent environments.
-version: 1.1.5
+version: 1.2.0
 repository: https://github.com/yordgenome03/cacherine
 
 dependencies:


### PR DESCRIPTION
## Overview

- **`CacheStatsDashboard`**: Added a class that wraps `CacheMetrics` and generates a typed `DashboardSnapshot` object
- **`TTLCache`**: Added an implementation of a standalone cache that supports TTL on a per-global-entry basis
- **`Disposable` interface**: Applied to all `Monitored*` caches and `TTLCache` to unify resource management for the timer controller
- **`formatDashboard()`**: Added a top-level function that renders a `DashboardSnapshot` as a terminal panel using Unicode box drawing (with adaptive latency unit formatting in µs / ms / s)

## Breaking Changes

> **Reason for a major version (v2.0.0):**

- **Implementation of the `Disposable` interface**: All `Monitored*` caches and `TTLCache` now implement `Disposable`. Subclasses must implement `dispose()`, and callers must call `.dispose()` to prevent timer leaks.
- **`ArgumentError` for invalid `Duration` values**: `CacheStatsDashboard.snapshot(Duration window)` now throws an `ArgumentError` if `window` is 0 or a negative value. `CacheStatsDashboard.stream(Duration window, Duration interval)` throws an `ArgumentError` if `interval` is 0 or a negative value.

## Migration Guide

```dart
// v1.x — No explicit cleanup required
final cache = MonitoredLRUCache<String, String>(maxSize: 100);

// v2.0.0 — Call `dispose()` after use
final cache = MonitoredLRUCache<String, String>(maxSize: 100);
// ...use the cache...
cache.dispose(); // Cancel the background timer
```

Translated with DeepL.com (free version)


## Stats Dashboard Usage

```dart
import ‘package:cacherine/cacherine.dart’;

void main() async {
  final cache = MonitoredLRUCache<String, String>(maxSize: 100);
  await cache.set(‘key’, ‘value’);
  await cache.get(‘key’);

  final dashboard = CacheStatsDashboard(cache.metrics);

  // One-time snapshot
  final snap = dashboard.snapshot(const Duration(minutes: 1));
  print(formatDashboard(snap));

  // Periodic stream (emit every 5 seconds)
  final sub = dashboard
      .stream(const Duration(minutes: 1), const Duration(seconds: 5))
      .listen((s) => print(formatDashboard(s)));

  await Future<void>.delayed(const Duration(seconds: 15));
  await sub.cancel();
  cache.dispose();
}
```

## CHANGELOG

See [CHANGELOG.md — v2.0.0](CHANGELOG.md) for the full entry.

## Test plan

- [x] `dart test` — All tests passed
- [x] `dart analyze` — No issues
- [x] Set `pubspec.yaml` version to `2.0.0`
- [x] Added v2.0.0 entry to the top of `CHANGELOG.md` (describing new features and breaking changes)
- [x] Verified that the `### Stats Dashboard Usage` section in README matches the current API

:robot_face: Generated with [Claude Code](https://claude.com/claude-code)