### PR TITLE
Improve monitored cache contracts and LFU eviction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <img src="https://github.com/user-attachments/assets/2a42a018-61cb-4ef7-a3d8-a0cafe923328" alt="cacherine logo" width="300"/>
 </p>
 
-`cacherine` is a simple and flexible memory cache library for Dart. It provides caching algorithms such as FIFO, LRU, MRU, LFU, and TTL-based expiry. Both single-threaded and async-enabled versions are available to handle different usage scenarios.
+`cacherine` is a simple and flexible memory cache library for Dart. It provides caching algorithms such as FIFO, LRU, MRU, LFU, and TTL-based expiry. Both synchronous and async-safe versions are available to handle different usage scenarios.
 
 If you want to choose the best cache algorithm for your app, you can use **MonitoredCache** in your development environment. It helps you monitor performance metrics (such as hit/miss rates, latency, and eviction alerts) so you can make data-driven decisions and optimize the algorithm you use.
 
@@ -21,7 +21,7 @@ If you want to choose the best cache algorithm for your app, you can use **Monit
 Dart/Flutter does not have a built-in caching solution similar to `NSCache` in Swift.  
 `cacherine` was created to provide a lightweight and flexible in-memory cache with common caching strategies like FIFO, LRU, MRU, and LFU.
 
-Whether you need a simple single-threaded cache or an async-compatible solution for concurrent environments, `cacherine` offers an easy-to-use API.
+Whether you need a simple synchronous cache or an async-compatible solution that serializes concurrent async calls within the same isolate, `cacherine` offers an easy-to-use API.
 
 ## Features
 
@@ -40,7 +40,7 @@ Whether you need a simple single-threaded cache or an async-compatible solution 
 - **MonitoredCache** (Includes performance monitoring with hit/miss rates, latency, and eviction alerts)
   — [Learn more](doc/monitored_cache.md)
 - **CacheStatsDashboard** (Wraps a MonitoredCache's metrics to provide point-in-time snapshots and periodic streams; `formatDashboard()` renders a Unicode terminal panel)
-- **Simple versions (e.g., SimpleFIFOCache) for single-threaded usage, and standard versions for multi-threaded environments**
+- **Simple versions (e.g., SimpleFIFOCache) for synchronous usage, and standard versions that serialize concurrent async calls within the same isolate**
 
 ## Installation
 
@@ -150,6 +150,14 @@ void main() async {
 }
 ```
 
+## API Contracts
+
+The standard and monitored cache variants use `Future` APIs and an internal lock to serialize concurrent async calls on the same cache instance within the same isolate. They are not shared-memory synchronization primitives across Dart isolates.
+
+`get()` returns `null` when a key is absent. Because the current API does not expose `containsKey()` or an entry wrapper, storing nullable values such as `Cache<String, String?>` is not supported: a stored `null` cannot be distinguished from a missing key.
+
+`toString()` is synchronous. It returns a point-in-time representation of the cache contents and should be treated as diagnostic output, not as a synchronized cache operation.
+
 ## API Reference
 
 - [FIFOCache<K, V>](lib/src/caches/fifo_cache.dart): FIFO-based cache
@@ -159,8 +167,8 @@ void main() async {
 - [LFUCache<K, V>](lib/src/caches/lfu_cache.dart): Cache that removes the least frequently used items
 - [TTLCache<K, V>](lib/src/caches/ttl_cache.dart): Cache with time-based expiry; global TTL with optional per-entry override, lazy eviction, optional background sweep, and optional capacity limit
 
-- [MonitoredFIFOCache<K, V>](lib/src/caches/monitored_ephemeral_fifo_cache.dart): FIFO-based cache with monitoring
-- [MonitoredEphemeralFIFOCache<K, V>](lib/src/caches/monitored_fifo_cache.dart): Ephemeral FIFO cache with monitoring
+- [MonitoredFIFOCache<K, V>](lib/src/caches/monitored_fifo_cache.dart): FIFO-based cache with monitoring
+- [MonitoredEphemeralFIFOCache<K, V>](lib/src/caches/monitored_ephemeral_fifo_cache.dart): Ephemeral FIFO cache with monitoring
 - [MonitoredLRUCache<K, V>](lib/src/caches/monitored_lru_cache.dart): LRU-based cache with monitoring
 - [MonitoredMRUCache<K, V>](lib/src/caches/monitored_mru_cache.dart): MRU-based cache with monitoring
 - [MonitoredLFUCache<K, V>](lib/src/caches/monitored_lfu_cache.dart): LFU-based cache with monitoring

--- a/doc/lfu_cache.md
+++ b/doc/lfu_cache.md
@@ -20,8 +20,8 @@ The LFU Cache eviction policy follows these rules:
 
 1. **Remove the data with the lowest frequency**
    - When the cache is full, the entry with the minimum access count is evicted.
-2. **FIFO for entries with the same frequency**
-   - If multiple entries have the same frequency, the oldest entry is evicted.
+2. **LRU for entries with the same frequency**
+   - If multiple entries have the same frequency, the least recently used entry within that frequency bucket is evicted.
 
 ## 3. Workflow
 
@@ -37,8 +37,8 @@ The LFU Cache eviction policy follows these rules:
 
 1. If the key exists:
    - Update the value.
-   - Increment the frequency counter.
-     (The key is treated as accessed, so its frequency increases.)
+   - Keep the existing frequency counter.
+   - Refresh its recency within the current frequency bucket.
 2. If the key does not exist:
    - If the cache exceeds the [maxSize], evict entries based on LFU policy.
    - Add the new key-value pair and initialize the frequency counter to 1.
@@ -86,7 +86,7 @@ The LFU Cache eviction policy follows these rules:
 
 6. set D (B evicted due to LFU)
 
-   - A new key D is added, requiring space in the cache (maxSize: 3). B and C have the same frequency of 1, but B is evicted because it was inserted first.
+   - A new key D is added, requiring space in the cache (maxSize: 3). B and C have the same frequency of 1, but B is evicted because it is least recently used within that frequency.
      | Order | Key | Frequency Count |
      |-------|-----|-----------------|
      | 0 | A | 2 |

--- a/doc/monitored_cache.md
+++ b/doc/monitored_cache.md
@@ -17,6 +17,7 @@ The **alert system** in `MonitoredCache` is powered by the `CacheAlertManager` c
 2. **`CacheAlertConfig`**:
 
    - Configures the alert thresholds for various cache metrics.
+   - Optional when creating monitored caches; omitted alert configuration uses a no-op notification callback with default thresholds.
    - Includes thresholds for:
      - **Hit rate**: Low hit rate detection.
      - **Miss rate**: High miss rate detection.

--- a/lib/src/caches/ephemeral_fifo_cache.dart
+++ b/lib/src/caches/ephemeral_fifo_cache.dart
@@ -3,13 +3,13 @@ import 'package:synchronized/synchronized.dart';
 
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe Ephemeral FIFO (First In, First Out) Cache**
+/// **Async-safe Ephemeral FIFO (First In, First Out) Cache**
 ///
 /// This class implements a **FIFO-based cache** with an **ephemeral property**,
 /// meaning that **values are immediately removed after being retrieved**.
 ///
-/// It extends [ThreadSafeCache] and ensures **thread safety using `Lock`**,
-/// allowing safe access from multiple threads or asynchronous tasks while preventing race conditions.
+/// It extends [ThreadSafeCache] and serializes concurrent async calls on the
+/// same cache instance within the same isolate using `Lock`.
 ///
 /// - **Adopts FIFO (First In, First Out) eviction policy**
 /// - **Removes the oldest element when the cache exceeds `maxSize`**
@@ -37,7 +37,7 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
 
   /// Returns all keys currently stored in the cache.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -49,7 +49,7 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - **Returns `null` if the key does not exist.**
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<V?> get(K key) async {
     return await _lock.synchronized(() {
@@ -63,7 +63,7 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
   /// - The updated key is treated as the **most recently added data**, but its order remains unchanged.
   /// - If the cache exceeds **[maxSize]**, the **oldest element is removed** according to the FIFO policy.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -80,7 +80,7 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - If the key does not exist, this call is a no-op.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -92,7 +92,7 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - Removes all keys and values from the cache.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -102,7 +102,8 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - Outputs **key-value pairs** currently stored in the cache as a string.
   ///
-  /// **This method is thread-safe.**
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache); // Take a snapshot of the cache

--- a/lib/src/caches/fifo_cache.dart
+++ b/lib/src/caches/fifo_cache.dart
@@ -3,11 +3,10 @@ import 'package:synchronized/synchronized.dart';
 
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe FIFO (First In, First Out) Cache**
+/// **Async-safe FIFO (First In, First Out) Cache**
 ///
-/// This class extends [ThreadSafeCache] and ensures **thread safety using `Lock`**.
-/// It allows **safe access to the cache from multiple threads or asynchronous tasks**,
-/// preventing data race conditions.
+/// This class extends [ThreadSafeCache] and serializes concurrent async calls
+/// on the same cache instance within the same isolate using `Lock`.
 ///
 /// **Adopts a FIFO eviction policy**,
 /// meaning **when the cache exceeds `maxSize`, the oldest element is removed**.
@@ -30,7 +29,7 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
 
   /// Returns all keys currently stored in the cache.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -43,7 +42,7 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
   /// - In FIFO, **the priority of data does not change** (retrieving with `get()` does not affect removal order).
   /// - **Returns `null` if the key does not exist.**
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<V?> get(K key) async {
     return await _lock.synchronized(() {
@@ -57,7 +56,7 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
   /// - The updated key is treated as **the most recent data**, but its order remains unchanged.
   /// - If the cache exceeds **[maxSize]**, the **oldest element is removed** following the FIFO policy.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -75,7 +74,7 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
   /// - If the key does not exist, this call is a no-op.
   /// - This is an O(n) operation because the underlying LinkedHashMap must be scanned.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -87,7 +86,7 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - Removes all keys and values from the cache.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -97,7 +96,8 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - Outputs **key-value pairs** currently stored in the cache as a string.
   ///
-  /// **This method is thread-safe.**
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache); // Take a snapshot of the cache

--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -11,15 +11,14 @@ final class _LFUNode<K, V> extends LinkedListEntry<_LFUNode<K, V>> {
   _LFUNode(this.key, this.value, this.freq);
 }
 
-/// **Thread-safe LFU (Least Frequently Used) Cache**
+/// **Async-safe LFU (Least Frequently Used) Cache**
 ///
-/// This class extends [ThreadSafeCache] and ensures **thread safety using `Lock`**.
-/// It allows **safe access to the cache from multiple threads or asynchronous tasks**,
-/// preventing data race conditions.
+/// This class extends [ThreadSafeCache] and serializes concurrent async calls
+/// on the same cache instance within the same isolate using `Lock`.
 ///
 /// **Exception:** [toString] is synchronous and does not acquire the lock.
 /// It returns a point-in-time snapshot of the cache contents but is not
-/// covered by the thread-safety guarantee. See [toString] for details.
+/// covered by the async-safety guarantee. See [toString] for details.
 ///
 /// **Adopts an LFU (Least Frequently Used) eviction policy**,
 /// meaning **when the cache exceeds `maxSize`, the least frequently used element is removed**.
@@ -47,7 +46,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   /// **Note:** The iteration order is unspecified (backed by [HashMap]).
   /// Do not rely on insertion order or any other stable ordering.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() => _keyMap.keys.toList());
@@ -82,7 +81,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - **Returns `null` if the key does not exist.**
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<V?> get(K key) async {
     return await _lock.synchronized(() {
@@ -103,7 +102,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   /// - If the cache exceeds **[maxSize]**, the **least frequently used element is removed** following the LFU policy.
   ///   Among entries with the same frequency, the least recently used is evicted.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -138,7 +137,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   /// - If the key does not exist, this call is a no-op.
   /// - The frequency counter for the key is also discarded.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -157,7 +156,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
 
   /// Clears the cache, removing all stored data.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> clear() async {
     await _lock.synchronized(() {
@@ -173,7 +172,7 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
   /// - The order of pairs is unspecified (backed by [HashMap]).
   ///
   /// **Note:** `toString()` is synchronous and does not acquire the internal
-  /// lock — it is the one method that does not honor the thread-safety
+  /// lock — it is the one method that does not honor the async-safety
   /// contract. The snapshot of keys and values is taken atomically within
   /// Dart's single-threaded execution model, so the snapshot itself cannot
   /// race with a concurrent async operation. However, the result reflects a

--- a/lib/src/caches/lru_cache.dart
+++ b/lib/src/caches/lru_cache.dart
@@ -3,11 +3,10 @@ import 'package:synchronized/synchronized.dart';
 
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe LRU (Least Recently Used) Cache**
+/// **Async-safe LRU (Least Recently Used) Cache**
 ///
-/// This class extends [ThreadSafeCache] and ensures **thread safety using `Lock`**.
-/// It allows **safe access to the cache from multiple threads or asynchronous tasks**,
-/// preventing data race conditions.
+/// This class extends [ThreadSafeCache] and serializes concurrent async calls
+/// on the same cache instance within the same isolate using `Lock`.
 ///
 /// **Adopts an LRU (Least Recently Used) eviction policy**,
 /// meaning **when the cache exceeds `maxSize`, the least recently used element is removed**.
@@ -30,7 +29,7 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
 
   /// Returns all keys currently stored in the cache.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -43,7 +42,7 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
   /// - **Uses the LRU policy**, meaning that **when a value is retrieved, the element is moved to the end of the list**.
   /// - **Returns `null` if the key does not exist.**
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<V?> get(K key) async {
     return await _lock.synchronized(() {
@@ -61,7 +60,7 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
   /// - If the cache exceeds **[maxSize]**,
   ///   the **least recently used element is removed** according to the LRU rule.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -82,7 +81,7 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - If the key does not exist, this call is a no-op.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -94,7 +93,7 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - Removes all keys and values from the cache.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -104,7 +103,8 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - Outputs **key-value pairs** currently stored in the cache as a string.
   ///
-  /// **This method is thread-safe.**
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache); // Take a snapshot of the cache

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -7,10 +7,10 @@ import '../monitorings/cache_monitoring.dart';
 import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe Ephemeral FIFO (First In, First Out) Cache with Monitoring**
+/// **Async-safe Ephemeral FIFO (First In, First Out) Cache with Monitoring**
 ///
-/// This class extends [ThreadSafeCache] and ensures thread-safety using a **`Lock`**.
-/// It allows safe access to the cache from multiple threads or asynchronous tasks, preventing data race conditions.
+/// This class extends [ThreadSafeCache] and serializes concurrent async calls
+/// on the same cache instance within the same isolate using `Lock`.
 ///
 /// Additionally, by utilizing the [CacheMonitoring] mixin, it automatically **monitors cache performance**.
 /// It records the following metrics and triggers alerts via the [CacheAlertManager] if thresholds are exceeded:
@@ -60,7 +60,7 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
 
   /// Returns all the keys currently stored in the cache.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -73,7 +73,7 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// - **Records cache hit/miss and measures request latency** via [CacheMonitoring].
   /// - **Returns `null` if the key does not exist in the cache.**
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<V?> get(K key) async {
     return await monitoredGet(key, () async {
@@ -88,7 +88,7 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key already exists, `set()` will **update its value** without changing its position.
   /// - If the cache size exceeds **[maxSize]**, the oldest element will be removed based on the FIFO policy.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -107,7 +107,7 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key existed, records a manual eviction via [CacheMonitoring].
   /// - If the key does not exist, this call is a no-op.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -122,7 +122,7 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - The monitoring function remains active even after the cache is cleared.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -135,7 +135,8 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - Outputs the **key-value pairs** stored in the cache.
   ///
-  /// **This method is thread-safe**.
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache); // Take a snapshot of the cache

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -49,7 +49,7 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// **Throws an [ArgumentError] if [maxSize] is less than or equal to 0.**
   MonitoredEphemeralFIFOCache({
     required this.maxSize,
-    required CacheAlertConfig alertConfig,
+    CacheAlertConfig alertConfig = const CacheAlertConfig(),
   }) {
     if (maxSize <= 0) {
       throw ArgumentError('maxSize must be greater than 0.');

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -53,7 +53,7 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// - **[ArgumentError]**: Thrown when [maxSize] is `0 or less`.
   MonitoredFIFOCache({
     required this.maxSize,
-    required CacheAlertConfig alertConfig,
+    CacheAlertConfig alertConfig = const CacheAlertConfig(),
   }) {
     if (maxSize <= 0) {
       throw ArgumentError('maxSize must be greater than 0.');

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -7,10 +7,10 @@ import '../monitorings/cache_monitoring.dart';
 import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe FIFO (First In, First Out) Cache with Monitoring**
+/// **Async-safe FIFO (First In, First Out) Cache with Monitoring**
 ///
-/// This class extends [ThreadSafeCache] and ensures thread-safety using a **`Lock`**.
-/// It allows safe access to the cache from multiple threads or asynchronous tasks, preventing data race conditions.
+/// This class extends [ThreadSafeCache] and serializes concurrent async calls
+/// on the same cache instance within the same isolate using `Lock`.
 ///
 /// Additionally, by utilizing the [CacheMonitoring] mixin, it automatically **monitors cache performance**.
 /// It records the following metrics and triggers alerts via the [CacheAlertManager] if thresholds are exceeded:
@@ -35,7 +35,7 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
 
   /// **Creates a [MonitoredFIFOCache] with a specified maximum size and alert configuration.**
   ///
-  /// This cache is thread-safe and monitors the following performance metrics:
+  /// This cache is async-safe and monitors the following performance metrics:
   ///
   /// - **Hit rate and miss rate**: Tracks the success/failure rate of cache accesses.
   /// - **Request latency**: Measures the response time for cache operations.
@@ -64,7 +64,7 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
 
   /// Returns all the keys currently stored in the cache.
   ///
-  /// **This method is thread-safe**, taking a snapshot of the cache before returning the keys.
+  /// **This method is async-safe**, taking a snapshot of the cache before returning the keys.
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -78,7 +78,7 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// - **The priority of data is not changed by FIFO** (the order of deletion is unchanged when calling `get()`).
   /// - Returns **`null` if the key does not exist in the cache**.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<V?> get(K key) async {
     return await monitoredGet(key, () async {
@@ -93,7 +93,7 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key already exists, `set()` will **update its value** without changing its position.
   /// - If the cache size exceeds **[maxSize]**, the oldest element will be removed based on the FIFO policy.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -112,7 +112,7 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key existed, records a manual eviction via [CacheMonitoring].
   /// - If the key does not exist, this call is a no-op.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -127,7 +127,7 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - The monitoring function remains active even after the cache is cleared.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -140,7 +140,8 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - Outputs the **key-value pairs** stored in the cache.
   ///
-  /// **This method is thread-safe**.
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache); // Take a snapshot of the cache

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -6,6 +6,14 @@ import '../monitorings/cache_monitoring.dart';
 import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
+final class _LFUNode<K, V> extends LinkedListEntry<_LFUNode<K, V>> {
+  K key;
+  V value;
+  int freq;
+
+  _LFUNode(this.key, this.value, this.freq);
+}
+
 /// **Thread-safe LFU (Least Frequently Used) Cache with Monitoring**
 ///
 /// This class extends [ThreadSafeCache] and ensures thread-safety using a **`Lock`**.
@@ -24,8 +32,9 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
     with CacheMonitoring<K, V>
     implements Disposable {
   final int maxSize;
-  final LinkedHashMap<K, V> _cache = LinkedHashMap();
-  final Map<K, int> _usageCounts = {};
+  final HashMap<K, _LFUNode<K, V>> _keyMap = HashMap();
+  final HashMap<int, LinkedList<_LFUNode<K, V>>> _freqMap = HashMap();
+  int _minFreq = 0;
   final _lock = Lock();
 
   /// Cache monitoring alert manager
@@ -68,8 +77,28 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
-      return Map<K, V>.of(_cache).keys;
+      return _keyMap.keys.toList();
     });
+  }
+
+  void _promoteFreq(_LFUNode<K, V> node) {
+    final oldFreq = node.freq;
+    final oldBucket = _freqMap[oldFreq]!;
+    node.unlink();
+    if (oldBucket.isEmpty) {
+      _freqMap.remove(oldFreq);
+      if (oldFreq == _minFreq) _minFreq = oldFreq + 1;
+    }
+    node.freq = oldFreq + 1;
+    _freqMap
+        .putIfAbsent(node.freq, LinkedList<_LFUNode<K, V>>.new)
+        .addFirst(node);
+  }
+
+  void _refreshInBucket(_LFUNode<K, V> node) {
+    final bucket = _freqMap[node.freq]!;
+    node.unlink();
+    bucket.addFirst(node);
   }
 
   /// Retrieves the value for the specified key and increments its usage count.
@@ -82,10 +111,10 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   Future<V?> get(K key) async {
     return await monitoredGet(key, () async {
       return await _lock.synchronized(() {
-        if (!_cache.containsKey(key)) return null;
-
-        _usageCounts[key] = (_usageCounts[key] ?? 0) + 1;
-        return _cache[key];
+        final node = _keyMap[key];
+        if (node == null) return null;
+        _promoteFreq(node);
+        return node.value;
       });
     });
   }
@@ -99,28 +128,32 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
-      if (_cache.containsKey(key)) {
-        _cache[key] = value;
+      final existing = _keyMap[key];
+      if (existing != null) {
+        existing.value = value;
+        _refreshInBucket(existing);
         return;
       }
-      if (_cache.length >= maxSize) {
+      if (_keyMap.length >= maxSize) {
         _evictLFUEntry();
         metrics.recordEviction();
       }
-      _cache[key] = value;
-      _usageCounts[key] = 1;
+      final node = _LFUNode(key, value, 1);
+      _keyMap[key] = node;
+      _freqMap.putIfAbsent(1, LinkedList<_LFUNode<K, V>>.new).addFirst(node);
+      _minFreq = 1;
     });
   }
 
   /// Performs eviction using the LFU (Least Frequently Used) policy.
   void _evictLFUEntry() {
-    if (_cache.isEmpty) return;
+    if (_keyMap.isEmpty) return;
 
-    final K lfuKey =
-        _usageCounts.entries.reduce((a, b) => a.value < b.value ? a : b).key;
-
-    _cache.remove(lfuKey);
-    _usageCounts.remove(lfuKey);
+    final evictBucket = _freqMap[_minFreq]!;
+    final victim = evictBucket.last;
+    victim.unlink();
+    if (evictBucket.isEmpty) _freqMap.remove(_minFreq);
+    _keyMap.remove(victim.key);
   }
 
   /// Removes the entry with the given key from the cache.
@@ -133,9 +166,14 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
-      if (_cache.containsKey(key)) {
-        _cache.remove(key);
-        _usageCounts.remove(key);
+      final node = _keyMap.remove(key);
+      if (node != null) {
+        final bucket = _freqMap[node.freq]!;
+        node.unlink();
+        if (bucket.isEmpty) {
+          _freqMap.remove(node.freq);
+          if (_keyMap.isEmpty) _minFreq = 0;
+        }
         metrics.recordEviction();
       }
     });
@@ -149,8 +187,9 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   @override
   Future<void> clear() async {
     await _lock.synchronized(() {
-      _cache.clear();
-      _usageCounts.clear();
+      _keyMap.clear();
+      _freqMap.clear();
+      _minFreq = 0;
     });
   }
 
@@ -164,7 +203,8 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   /// **This method is thread-safe**.
   @override
   String toString() {
-    final snapshot = Map.of(_cache);
-    return snapshot.toString();
+    return Map.fromEntries(
+      _keyMap.values.toList().map((node) => MapEntry(node.key, node.value)),
+    ).toString();
   }
 }

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -53,7 +53,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   /// - **[ArgumentError]**: Thrown when [maxSize] is `0 or less`.
   MonitoredLFUCache({
     required this.maxSize,
-    required CacheAlertConfig alertConfig,
+    CacheAlertConfig alertConfig = const CacheAlertConfig(),
   }) {
     if (maxSize <= 0) {
       throw ArgumentError('maxSize must be greater than 0.');

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -14,10 +14,10 @@ final class _LFUNode<K, V> extends LinkedListEntry<_LFUNode<K, V>> {
   _LFUNode(this.key, this.value, this.freq);
 }
 
-/// **Thread-safe LFU (Least Frequently Used) Cache with Monitoring**
+/// **Async-safe LFU (Least Frequently Used) Cache with Monitoring**
 ///
-/// This class extends [ThreadSafeCache] and ensures thread-safety using a **`Lock`**.
-/// It allows safe access to the cache from multiple threads or asynchronous tasks, preventing data race conditions.
+/// This class extends [ThreadSafeCache] and serializes concurrent async calls
+/// on the same cache instance within the same isolate using `Lock`.
 ///
 /// Additionally, by utilizing the [CacheMonitoring] mixin, it automatically **monitors cache performance**.
 /// It records the following metrics and triggers alerts via the [CacheAlertManager] if thresholds are exceeded:
@@ -44,7 +44,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
 
   /// **Creates a [MonitoredLFUCache] with a specified maximum size and alert configuration.**
   ///
-  /// This cache is thread-safe and monitors the following performance metrics:
+  /// This cache is async-safe and monitors the following performance metrics:
   ///
   /// - **Hit rate and miss rate**: Tracks the success/failure rate of cache accesses.
   /// - **Request latency**: Measures the response time for cache operations.
@@ -73,7 +73,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
 
   /// Returns all the keys currently stored in the cache.
   ///
-  /// **This method is thread-safe**, taking a snapshot of the cache before returning the keys.
+  /// **This method is async-safe**, taking a snapshot of the cache before returning the keys.
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -106,7 +106,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   /// - **Records cache hit/miss and measures request latency** via [CacheMonitoring].
   /// - **Returns `null` if the key does not exist in the cache**.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<V?> get(K key) async {
     return await monitoredGet(key, () async {
@@ -124,7 +124,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key already exists, `set()` will **update its value** without resetting its usage count.
   /// - If the cache size exceeds **[maxSize]**, the least frequently used element will be removed based on the LFU policy.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -162,7 +162,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key does not exist, this call is a no-op.
   /// - The frequency counter for the key is also discarded.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -183,7 +183,7 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - The monitoring function remains active even after the cache is cleared.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> clear() async {
     await _lock.synchronized(() {
@@ -200,7 +200,8 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - Outputs **key-value pairs** currently stored in the cache as a string.
   ///
-  /// **This method is thread-safe**.
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     return Map.fromEntries(

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -53,7 +53,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - **[ArgumentError]**: Thrown when [maxSize] is `0 or less`.
   MonitoredLRUCache({
     required this.maxSize,
-    required CacheAlertConfig alertConfig,
+    CacheAlertConfig alertConfig = const CacheAlertConfig(),
   }) {
     if (maxSize <= 0) {
       throw ArgumentError('maxSize must be greater than 0.');

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -7,10 +7,10 @@ import '../monitorings/cache_monitoring.dart';
 import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe LRU (Least Recently Used) Cache with Monitoring**
+/// **Async-safe LRU (Least Recently Used) Cache with Monitoring**
 ///
-/// This class extends [ThreadSafeCache] and ensures thread-safety using a **`Lock`**.
-/// It allows safe access to the cache from multiple threads or asynchronous tasks, preventing data race conditions.
+/// This class extends [ThreadSafeCache] and serializes concurrent async calls
+/// on the same cache instance within the same isolate using `Lock`.
 ///
 /// Additionally, by utilizing the [CacheMonitoring] mixin, it automatically **monitors cache performance**.
 /// It records the following metrics and triggers alerts via the [CacheAlertManager] if thresholds are exceeded:
@@ -35,7 +35,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
 
   /// **Creates a [MonitoredLRUCache] with a specified maximum size and alert configuration.**
   ///
-  /// This cache is thread-safe and monitors the following performance metrics:
+  /// This cache is async-safe and monitors the following performance metrics:
   ///
   /// - **Hit rate and miss rate**: Tracks the success/failure rate of cache accesses.
   /// - **Request latency**: Measures the response time for cache operations.
@@ -64,7 +64,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
 
   /// Returns all the keys currently stored in the cache.
   ///
-  /// **This method is thread-safe**, taking a snapshot of the cache before returning the keys.
+  /// **This method is async-safe**, taking a snapshot of the cache before returning the keys.
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -78,7 +78,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - **Implements the LRU policy**, meaning the accessed element is **moved to the end of the list**.
   /// - **Returns `null` if the key does not exist in the cache**.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<V?> get(K key) async {
     return await monitoredGet(key, () async {
@@ -97,7 +97,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key already exists, `set()` will **update its value** and move it to the end (LRU policy).
   /// - If the cache size exceeds **[maxSize]**, the **least recently used element will be removed** following the LRU rule.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -120,7 +120,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key existed, records a manual eviction via [CacheMonitoring].
   /// - If the key does not exist, this call is a no-op.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -135,7 +135,7 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - The monitoring function remains active even after the cache is cleared.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -148,7 +148,8 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - Outputs **key-value pairs** currently stored in the cache as a string.
   ///
-  /// **This method is thread-safe**.
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache);

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -6,10 +6,10 @@ import '../monitorings/cache_monitoring.dart';
 import '../interfaces/disposable.dart';
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe MRU (Most Recently Used) Cache with Monitoring**
+/// **Async-safe MRU (Most Recently Used) Cache with Monitoring**
 ///
-/// Ensures **safe access to the cache from multiple threads or asynchronous tasks** by using `Lock`
-/// to maintain thread safety.
+/// This class serializes concurrent async calls on the same cache instance
+/// within the same isolate using `Lock`.
 ///
 /// Additionally, by utilizing the [CacheMonitoring] mixin, it automatically **monitors cache performance**.
 /// It records the following metrics and triggers alerts via the [CacheAlertManager] if thresholds are exceeded:
@@ -34,7 +34,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
 
   /// **Creates a [MonitoredMRUCache] with a specified maximum size and alert configuration.**
   ///
-  /// This cache is thread-safe and monitors the following performance metrics:
+  /// This cache is async-safe and monitors the following performance metrics:
   ///
   /// - **Hit rate and miss rate**: Tracks the success/failure rate of cache accesses.
   /// - **Request latency**: Measures the response time for cache operations.
@@ -63,7 +63,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
 
   /// Returns all keys currently stored in the cache.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -77,7 +77,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - **If the key exists, it is removed and reinserted to mark it as "recently used".**
   /// - **Returns `null` if the key does not exist in the cache.**
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<V?> get(K key) async {
     return await monitoredGet(key, () async {
@@ -98,7 +98,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key already exists, `set()` will **update its value** and move it to the most recently used position.
   /// - If the cache size exceeds **[maxSize]**, the **most recently used element will be removed** based on the MRU policy.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -128,7 +128,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - If the key existed, records a manual eviction via [CacheMonitoring].
   /// - If the key does not exist, this call is a no-op.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -143,7 +143,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - The monitoring function remains active even after the cache is cleared.
   ///
-  /// **This method is thread-safe**.
+  /// **This method is async-safe**.
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -156,7 +156,8 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   ///
   /// - Outputs **key-value pairs** currently stored in the cache as a string.
   ///
-  /// **This method is thread-safe**.
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache);

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -52,7 +52,7 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
   /// - **[ArgumentError]**: Thrown when [maxSize] is `0 or less`.
   MonitoredMRUCache({
     required this.maxSize,
-    required CacheAlertConfig alertConfig,
+    CacheAlertConfig alertConfig = const CacheAlertConfig(),
   }) {
     if (maxSize <= 0) {
       throw ArgumentError('maxSize must be greater than 0.');

--- a/lib/src/caches/mru_cache.dart
+++ b/lib/src/caches/mru_cache.dart
@@ -3,11 +3,10 @@ import 'package:synchronized/synchronized.dart';
 
 import '../interfaces/thread_safe_cache.dart';
 
-/// **Thread-safe MRU (Most Recently Used) Cache**
+/// **Async-safe MRU (Most Recently Used) Cache**
 ///
-/// This class ensures **thread safety using `Lock`**,
-/// allowing **safe access to the cache from multiple threads or asynchronous tasks**
-/// while preventing data race conditions.
+/// This class serializes concurrent async calls on the same cache instance
+/// within the same isolate using `Lock`.
 ///
 /// **Adopts the MRU (Most Recently Used) eviction policy**,
 /// meaning **when the cache exceeds `maxSize`, the most recently accessed element is removed**.
@@ -30,7 +29,7 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
 
   /// Returns all keys currently stored in the cache.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<Iterable<K>> getKeys() async {
     return await _lock.synchronized(() {
@@ -43,7 +42,7 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
   /// - **If the key exists, it is removed and reinserted to mark it as "recently used."**
   /// - **Returns `null` if the key does not exist.**
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<V?> get(K key) async {
     return await _lock.synchronized(() {
@@ -63,7 +62,7 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///   and **its order is updated to mark it as "recently used."**
   /// - If the cache exceeds **[maxSize]**, the **most recently used element is removed** following the MRU policy.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> set(K key, V value) async {
     await _lock.synchronized(() {
@@ -91,7 +90,7 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - If the key does not exist, this call is a no-op.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
@@ -101,7 +100,7 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
 
   /// Clears the cache, removing all stored data.
   ///
-  /// **This method is thread-safe.**
+  /// **This method is async-safe.**
   @override
   Future<void> clear() async {
     await _lock.synchronized(_cache.clear);
@@ -111,7 +110,8 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
   ///
   /// - Outputs **key-value pairs** currently stored in the cache as a string.
   ///
-  /// **This method is thread-safe.**
+  /// **Note:** `toString()` is synchronous and does not acquire the internal
+  /// lock. Treat the result as diagnostic output for a point-in-time view.
   @override
   String toString() {
     final snapshot = Map.of(_cache); // Take a snapshot of the cache

--- a/lib/src/interfaces/thread_safe_cache.dart
+++ b/lib/src/interfaces/thread_safe_cache.dart
@@ -1,9 +1,10 @@
-/// **Thread-safe Cache Interface**
+/// **Async-safe Cache Interface**
 ///
-/// An abstract class defining the basic cache operations for **multi-threaded environments**
-/// and **asynchronous processing**.
-/// - Provides **thread-safe cache operations** using **asynchronous processing (`Future`)**.
-/// - Designed to **safely handle access from multiple threads**.
+/// An abstract class defining basic cache operations for asynchronous use.
+///
+/// Implementations serialize concurrent async calls on the same cache instance
+/// within the same isolate. They are not shared-memory synchronization
+/// primitives across Dart isolates.
 abstract class ThreadSafeCache<K, V> {
   /// **Retrieves all keys stored in the cache.**
   ///

--- a/lib/src/monitorings/cache_alert_manager.dart
+++ b/lib/src/monitorings/cache_alert_manager.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'cache_metrics.dart';
 
+void _noopAlertCallback(String _) {}
+
 /// Cache alert management class
 ///
 /// This class monitors cache performance and triggers alerts when the user-defined
@@ -97,8 +99,8 @@ class CacheAlertConfig {
   /// [notifyCallback] is the function used to notify about alerts,
   /// the various thresholds set user-defined limits for performance metrics,
   /// and [alertCheckInterval] sets the interval for checking alerts.
-  CacheAlertConfig({
-    required this.notifyCallback,
+  const CacheAlertConfig({
+    this.notifyCallback = _noopAlertCallback,
     this.hitRateThreshold = 0.5,
     this.missRateThreshold = 0.5,
     this.p95LatencyThreshold = 200,

--- a/test/caches/monitored_cache_constructor_test.dart
+++ b/test/caches/monitored_cache_constructor_test.dart
@@ -20,5 +20,32 @@ void main() {
 
       expect(caches, everyElement(isA<Disposable>()));
     });
+
+    test('toString() returns current entries for monitored caches', () async {
+      final fifo = MonitoredFIFOCache<String, String>(maxSize: 2);
+      final ephemeral = MonitoredEphemeralFIFOCache<String, String>(maxSize: 2);
+      final lru = MonitoredLRUCache<String, String>(maxSize: 2);
+      final mru = MonitoredMRUCache<String, String>(maxSize: 2);
+      final lfu = MonitoredLFUCache<String, String>(maxSize: 2);
+      final caches = <Disposable>[fifo, ephemeral, lru, mru, lfu];
+
+      addTearDown(() {
+        for (final cache in caches) {
+          cache.dispose();
+        }
+      });
+
+      await fifo.set('key', 'fifo');
+      await ephemeral.set('key', 'ephemeral');
+      await lru.set('key', 'lru');
+      await mru.set('key', 'mru');
+      await lfu.set('key', 'lfu');
+
+      expect(fifo.toString(), contains('fifo'));
+      expect(ephemeral.toString(), contains('ephemeral'));
+      expect(lru.toString(), contains('lru'));
+      expect(mru.toString(), contains('mru'));
+      expect(lfu.toString(), contains('lfu'));
+    });
   });
 }

--- a/test/caches/monitored_cache_constructor_test.dart
+++ b/test/caches/monitored_cache_constructor_test.dart
@@ -1,0 +1,24 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Monitored cache constructors', () {
+    test('use a no-op alert configuration by default', () {
+      final caches = <Disposable>[
+        MonitoredFIFOCache<String, String>(maxSize: 2),
+        MonitoredEphemeralFIFOCache<String, String>(maxSize: 2),
+        MonitoredLRUCache<String, String>(maxSize: 2),
+        MonitoredMRUCache<String, String>(maxSize: 2),
+        MonitoredLFUCache<String, String>(maxSize: 2),
+      ];
+
+      addTearDown(() {
+        for (final cache in caches) {
+          cache.dispose();
+        }
+      });
+
+      expect(caches, everyElement(isA<Disposable>()));
+    });
+  });
+}

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -179,6 +179,26 @@ void main() {
       expect(await cache.get('keyC'), equals('valueC'));
     });
 
+    test(
+      'set() on an existing key refreshes recency among same-frequency entries',
+      () async {
+        final cache = MonitoredLFUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+        await cache.set('keyA', 'valueA');
+        await cache.set('keyB', 'valueB');
+
+        await cache.set('keyB', 'updatedB');
+        await cache.set('keyC', 'valueC');
+
+        expect(await cache.get('keyA'), isNull);
+        expect(await cache.get('keyB'), equals('updatedB'));
+        expect(await cache.get('keyC'), equals('valueC'));
+      },
+    );
+
     test('Should throw an exception if maxSize is 0 or negative', () {
       expect(
         () =>

--- a/test/caches/monitored_lfu_cache_test.dart
+++ b/test/caches/monitored_lfu_cache_test.dart
@@ -180,6 +180,26 @@ void main() {
     });
 
     test(
+      'get() promotes the only entry in the minimum frequency bucket',
+      () async {
+        final cache = MonitoredLFUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('keyA', 'valueA');
+        await cache.get('keyA');
+        await cache.set('keyB', 'valueB');
+        await cache.set('keyC', 'valueC');
+
+        expect(await cache.get('keyA'), equals('valueA'));
+        expect(await cache.get('keyB'), isNull);
+        expect(await cache.get('keyC'), equals('valueC'));
+      },
+    );
+
+    test(
       'set() on an existing key refreshes recency among same-frequency entries',
       () async {
         final cache = MonitoredLFUCache<String, String>(
@@ -222,6 +242,29 @@ void main() {
       final stats = cache.metrics.getRecentStats(const Duration(minutes: 1));
       expect(stats['evictions_per_minute'], equals(1));
     });
+
+    test(
+      'remove() promoted key keeps remaining frequency buckets usable',
+      () async {
+        final cache = MonitoredLFUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+        await cache.get('key1');
+        await cache.remove('key1');
+        await cache.set('key3', 'value3');
+        await cache.set('key4', 'value4');
+
+        expect(await cache.get('key1'), isNull);
+        expect(await cache.get('key2'), isNull);
+        expect(await cache.get('key3'), equals('value3'));
+        expect(await cache.get('key4'), equals('value4'));
+      },
+    );
 
     test('remove() non-existent key does not record eviction', () async {
       final cache = MonitoredLFUCache<String, String>(

--- a/test/caches/monitored_lru_cache_test.dart
+++ b/test/caches/monitored_lru_cache_test.dart
@@ -95,6 +95,25 @@ void main() {
       expect(await cache.getKeys(), isEmpty);
     });
 
+    test(
+      'set() on an existing key updates value and refreshes recency',
+      () async {
+        final cache = MonitoredLRUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+        await cache.set('key1', 'updated1');
+        await cache.set('key3', 'value3');
+
+        expect(await cache.get('key1'), equals('updated1'));
+        expect(await cache.get('key2'), isNull);
+        expect(await cache.get('key3'), equals('value3'));
+      },
+    );
+
     test('Should throw an exception if maxSize is 0 or negative', () {
       expect(
         () =>

--- a/test/caches/monitored_mru_cache_test.dart
+++ b/test/caches/monitored_mru_cache_test.dart
@@ -92,6 +92,25 @@ void main() {
       expect(await cache.getKeys(), isEmpty);
     });
 
+    test(
+      'set() on an existing key updates value and refreshes recency',
+      () async {
+        final cache = MonitoredMRUCache<String, String>(
+          maxSize: 2,
+          alertConfig: config,
+        );
+
+        await cache.set('key1', 'value1');
+        await cache.set('key2', 'value2');
+        await cache.set('key1', 'updated1');
+        await cache.set('key3', 'value3');
+
+        expect(await cache.get('key1'), isNull);
+        expect(await cache.get('key2'), equals('value2'));
+        expect(await cache.get('key3'), equals('value3'));
+      },
+    );
+
     test('Should throw an exception if maxSize is 0 or negative', () {
       expect(
         () =>

--- a/test/monitorings/cache_alert_manager_test.dart
+++ b/test/monitorings/cache_alert_manager_test.dart
@@ -3,6 +3,14 @@ import 'package:cacherine/cacherine.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('CacheAlertConfig', () {
+    test('default notify callback is a no-op', () {
+      const config = CacheAlertConfig();
+
+      expect(() => config.notifyCallback('ignored'), returnsNormally);
+    });
+  });
+
   group('CacheAlertManager - Alert Triggering', () {
     late CacheMetrics metrics;
     late List<String> receivedAlerts;


### PR DESCRIPTION
## 📝 PR Summary

This PR fixes monitored cache API inconsistencies, aligns monitored LFU eviction behavior with the standard LFU cache, and clarifies the public async cache contracts.

### 🐛 Bugfix | 🚀 Feature | 📖 Documentation Update | 🚀 Release

- [x] Bugfix
- [x] Feature
- [x] Documentation Update
- [ ] Release

### 🔧 Fix / Feature Details

- **Issue:** `Monitored*Cache` constructors required `alertConfig`, while README examples used monitored caches without it.
- **Fix / Feature:** Added a no-op default `CacheAlertConfig` and made `alertConfig` optional across all monitored cache constructors.

- **Issue:** `MonitoredLFUCache` used O(n) eviction and did not match the standard LFU cache tie-break behavior.
- **Fix / Feature:** Reworked `MonitoredLFUCache` to use frequency buckets for constant-time LFU eviction, preserving same-frequency LRU tie-breaking.

- **Issue:** README links for `MonitoredFIFOCache` and `MonitoredEphemeralFIFOCache` were swapped.
- **Fix / Feature:** Corrected the API reference links.

- **Issue:** Documentation used potentially misleading `thread-safe` wording and did not clearly define nullable values or `toString()` behavior.
- **Fix / Feature:** Clarified that async caches serialize concurrent async calls within the same isolate, documented `toString()` as synchronous diagnostic output, and documented nullable values as unsupported by the current API.

### 📌 Related Issue

N/A

---

## 🔍 Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests (if applicable)

Test commands:

```sh
/Users/yotahara/fvm/versions/stable/bin/dart analyze
/Users/yotahara/fvm/versions/stable/bin/dart test
```

Results:

- `dart analyze`: no issues found
- `dart test`: all tests passed

---

## 📖 Documentation Update (if applicable)

### 🔧 Documentation Changes

- [x] Updated README
- [x] Updated API reference
- [ ] Added new guides/tutorials

### 🚀 Additional Notes

This PR intentionally documents nullable values as unsupported instead of introducing a breaking generic bound change. Full nullable-value support can be handled separately with a `containsKey()` or entry-wrapper API.

---

## 🚀 Release Checklist (if applicable)

### 📌 Release Checklist

- [ ] **Bump version in `pubspec.yaml`**
- [ ] **Update `CHANGELOG.md` with release notes**
- [ ] **Update `README.md` if necessary**
- [x] **Run `dart analyze` to ensure no issues**
- [x] **Run `dart test` to confirm all tests pass**
- [ ] **Ensure all dependencies are up to date**
- [ ] **Tag the release commit after merging**

<!-- Release Summary -->
<!--
### 📝 Release Summary
[//]: # "Provide a summary of this release (e.g., major changes, bug fixes, improvements)"

### 🔧 Release Changes

- [ ] Feature A
- [ ] Improvement B
- [ ] Bugfix C

### 🏷 Versioning

- **Current Version:** `X.Y.Z`
- **New Version:** `X.Y.Z+1`

### 🚀 Additional Notes

[//]: # "Any additional context, related issues, or references"
-->
