### PR TITLE
feat(cache): add monitored TTL cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### New Features
+
+- **MonitoredTTLCache**: Added a monitored TTL cache variant with hit/miss and latency metrics, eviction tracking for expiry/capacity/manual removals, alert support, and the same TTL configuration options as `TTLCache`.
+
 ## 2.0.1 - LFU Performance Improvements, Bug Fixes, and Maintenance
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Whether you need a simple synchronous cache or an async-compatible solution that
   — [Learn more](doc/ttl_cache.md)
 - **MonitoredCache** (Includes performance monitoring with hit/miss rates, latency, and eviction alerts)
   — [Learn more](doc/monitored_cache.md)
+- **MonitoredTTLCache** (TTL-based expiry with the same monitoring metrics and alerts as other monitored cache variants)
 - **CacheStatsDashboard** (Wraps a MonitoredCache's metrics to provide point-in-time snapshots and periodic streams; `formatDashboard()` renders a Unicode terminal panel)
 - **Simple versions (e.g., SimpleFIFOCache) for synchronous usage, and standard versions that serialize concurrent async calls within the same isolate**
 
@@ -172,6 +173,7 @@ The standard and monitored cache variants use `Future` APIs and an internal lock
 - [MonitoredLRUCache<K, V>](lib/src/caches/monitored_lru_cache.dart): LRU-based cache with monitoring
 - [MonitoredMRUCache<K, V>](lib/src/caches/monitored_mru_cache.dart): MRU-based cache with monitoring
 - [MonitoredLFUCache<K, V>](lib/src/caches/monitored_lfu_cache.dart): LFU-based cache with monitoring
+- [MonitoredTTLCache<K, V>](lib/src/caches/monitored_ttl_cache.dart): TTL-based cache with monitoring
 
 - [CacheStatsDashboard](lib/src/monitorings/cache_stats_dashboard.dart): Wraps `CacheMetrics` to provide `snapshot(Duration window)` and `stream(Duration window, Duration interval)`
 - [DashboardSnapshot](lib/src/monitorings/cache_stats_dashboard.dart): Immutable point-in-time snapshot (hitRate, missRate, latency percentiles, evictionsPerMinute, totalRequests, capturedAt)

--- a/doc/ttl_cache.md
+++ b/doc/ttl_cache.md
@@ -99,7 +99,33 @@ cache.dispose(); // cancel sweep timer
 
 `dispose()` is idempotent — calling it multiple times is safe. After `dispose()`, `get()` and `set()` continue to work; only the background sweep stops.
 
-## 5. API Reference
+## 5. Monitoring
+
+Use `MonitoredTTLCache` when you need TTL expiry together with `CacheMetrics`,
+`CacheStatsDashboard`, or alert thresholds. It supports the same TTL options as
+`TTLCache` (`ttl`, per-entry `ttl:`, `maxSize`, `sweepInterval`, and `clock`) and
+records:
+
+- Hits and misses for `get()` calls.
+- Latency for each `get()` call.
+- Evictions when entries are removed by expiry, capacity limits, or explicit `remove()` calls.
+
+```dart
+final cache = MonitoredTTLCache<String, String>(
+  ttl: Duration(minutes: 5),
+  maxSize: 100,
+);
+
+await cache.set('token', 'abc123');
+await cache.get('token');
+
+final snapshot = cache.metrics.snapshot(Duration(minutes: 1));
+print(snapshot.hitRate);
+
+cache.dispose();
+```
+
+## 6. API Reference
 
 | Method | Description |
 |--------|-------------|
@@ -110,7 +136,7 @@ cache.dispose(); // cancel sweep timer
 | `clear()` | Remove all entries. |
 | `dispose()` | Cancel the background sweep timer. Idempotent. |
 
-## 6. Constructor Parameters
+## 7. Constructor Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -119,7 +145,7 @@ cache.dispose(); // cancel sweep timer
 | `sweepInterval` | `Duration?` | No | Interval for background expired-entry removal. No sweep if omitted. |
 | `clock` | `DateTime Function()?` | No | Time source. Defaults to `DateTime.now`. Inject a fake clock in tests. |
 
-## 7. Suitable Use Cases
+## 8. Suitable Use Cases
 
 TTL Cache is well-suited for data with a natural validity window:
 
@@ -128,7 +154,7 @@ TTL Cache is well-suited for data with a natural validity window:
 - **Computed values with bounded validity**: Cache expensive computations that are known to be stale after a fixed interval (e.g., exchange rates, configuration snapshots).
 - **Rate-limiting state**: Track per-key counters that should reset after a time window.
 
-## 8. Choosing Between TTLCache and Capacity-Based Caches
+## 9. Choosing Between TTLCache and Capacity-Based Caches
 
 | | Capacity-based (FIFO/LRU/etc.) | TTLCache |
 |-|-------------------------------|----------|

--- a/lib/cacherine.dart
+++ b/lib/cacherine.dart
@@ -31,6 +31,7 @@ export 'src/caches/monitored_fifo_cache.dart';
 export 'src/caches/monitored_lru_cache.dart';
 export 'src/caches/monitored_mru_cache.dart';
 export 'src/caches/monitored_lfu_cache.dart';
+export 'src/caches/monitored_ttl_cache.dart';
 
 // TTL Cache
 export 'src/caches/ttl_cache.dart';

--- a/lib/src/caches/monitored_ttl_cache.dart
+++ b/lib/src/caches/monitored_ttl_cache.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:synchronized/synchronized.dart';
+
+import '../interfaces/disposable.dart';
+import '../interfaces/thread_safe_cache.dart';
+import '../monitorings/cache_alert_manager.dart';
+import '../monitorings/cache_monitoring.dart';
+
+class _TTLEntry<V> {
+  final V value;
+  final DateTime expiry;
+
+  _TTLEntry(this.value, this.expiry);
+}
+
+/// **Async-safe TTL (Time-To-Live) Cache with Monitoring**
+///
+/// Entries are treated as absent once their TTL has elapsed. Expired entries
+/// are removed lazily on [get], proactively by an optional background sweep,
+/// and during capacity checks when [maxSize] is configured.
+///
+/// This cache records hit/miss latency through [CacheMonitoring] and records
+/// eviction events when entries are removed due to expiry, capacity limits, or
+/// explicit [remove] calls.
+class MonitoredTTLCache<K, V> extends ThreadSafeCache<K, V>
+    with CacheMonitoring<K, V>
+    implements Disposable {
+  final Duration _globalTTL;
+  final int? _maxSize;
+  final DateTime Function() _clock;
+
+  final LinkedHashMap<K, _TTLEntry<V>> _cache = LinkedHashMap();
+  final _lock = Lock();
+  Timer? _sweepTimer;
+
+  late final CacheAlertManager _cacheAlertManager;
+
+  /// Creates a [MonitoredTTLCache].
+  ///
+  /// - [ttl]: Default expiry duration for entries stored via [set].
+  /// - [maxSize]: Optional capacity limit; the oldest inserted live entry is
+  ///   evicted when the limit is exceeded.
+  /// - [sweepInterval]: Optional background interval for removing expired
+  ///   entries.
+  /// - [clock]: Injectable time source for testing; defaults to [DateTime.now].
+  /// - [alertConfig]: Optional alert configuration for monitoring thresholds.
+  MonitoredTTLCache({
+    required Duration ttl,
+    int? maxSize,
+    Duration? sweepInterval,
+    DateTime Function()? clock,
+    CacheAlertConfig? alertConfig,
+  }) : _globalTTL = ttl,
+       _maxSize = maxSize,
+       _clock = clock ?? DateTime.now {
+    if (ttl <= Duration.zero) {
+      throw ArgumentError('ttl must be greater than zero.');
+    }
+    if (maxSize != null && maxSize <= 0) {
+      throw ArgumentError('maxSize must be greater than 0.');
+    }
+    if (sweepInterval != null && sweepInterval <= Duration.zero) {
+      throw ArgumentError('sweepInterval must be greater than zero.');
+    }
+
+    _cacheAlertManager = CacheAlertManager(
+      metrics,
+      alertConfig ?? CacheAlertConfig(),
+    );
+    _cacheAlertManager.monitor();
+
+    if (sweepInterval != null) {
+      _sweepTimer = Timer.periodic(sweepInterval, (_) => _sweep());
+    }
+  }
+
+  void _sweep() {
+    unawaited(
+      _lock.synchronized(() {
+        final evicted = _removeExpired(_clock());
+        _recordEvictions(evicted);
+      }),
+    );
+  }
+
+  int _removeExpired(DateTime now) {
+    var evicted = 0;
+    _cache.removeWhere((_, entry) {
+      final expired = !entry.expiry.isAfter(now);
+      if (expired) evicted++;
+      return expired;
+    });
+    return evicted;
+  }
+
+  void _evictIfNeeded() {
+    final maxSize = _maxSize;
+    if (maxSize == null || _cache.length < maxSize) return;
+
+    final expiredEvictions = _removeExpired(_clock());
+    _recordEvictions(expiredEvictions);
+
+    var capacityEvictions = 0;
+    while (_cache.length >= maxSize) {
+      _cache.remove(_cache.keys.first);
+      capacityEvictions++;
+    }
+    _recordEvictions(capacityEvictions);
+  }
+
+  void _recordEvictions(int count) {
+    for (var i = 0; i < count; i++) {
+      metrics.recordEviction();
+    }
+  }
+
+  @override
+  Future<Iterable<K>> getKeys() async {
+    return await _lock.synchronized(() {
+      final now = _clock();
+      return _cache.entries
+          .where((e) => e.value.expiry.isAfter(now))
+          .map((e) => e.key)
+          .toList();
+    });
+  }
+
+  @override
+  Future<V?> get(K key) async {
+    var found = false;
+    return await monitoredGet(key, () async {
+      return await _lock.synchronized(() {
+        final entry = _cache[key];
+        if (entry == null) return null;
+        if (!entry.expiry.isAfter(_clock())) {
+          _cache.remove(key);
+          metrics.recordEviction();
+          return null;
+        }
+        found = true;
+        return entry.value;
+      });
+    }, found: () => found);
+  }
+
+  /// Stores [key]/[value] in the cache.
+  ///
+  /// - [ttl]: Per-entry TTL override. When omitted, the global TTL is used.
+  /// - Updating an existing key refreshes its insertion order for FIFO capacity
+  ///   eviction purposes.
+  @override
+  Future<void> set(K key, V value, {Duration? ttl}) async {
+    if (ttl != null && ttl <= Duration.zero) {
+      throw ArgumentError('ttl must be greater than zero.');
+    }
+    await _lock.synchronized(() {
+      _cache.remove(key);
+      _evictIfNeeded();
+      _cache[key] = _TTLEntry(value, _clock().add(ttl ?? _globalTTL));
+    });
+  }
+
+  @override
+  Future<void> remove(K key) async {
+    await _lock.synchronized(() {
+      if (_cache.remove(key) != null) {
+        metrics.recordEviction();
+      }
+    });
+  }
+
+  @override
+  Future<void> clear() async {
+    await _lock.synchronized(_cache.clear);
+  }
+
+  @override
+  void dispose() {
+    _sweepTimer?.cancel();
+    _sweepTimer = null;
+    _cacheAlertManager.dispose();
+  }
+
+  @override
+  String toString() {
+    final now = _clock();
+    final snapshot = Map.fromEntries(
+      _cache.entries
+          .where((e) => e.value.expiry.isAfter(now))
+          .map((e) => MapEntry(e.key, e.value.value)),
+    );
+    return snapshot.toString();
+  }
+}

--- a/test/caches/monitored_ttl_cache_test.dart
+++ b/test/caches/monitored_ttl_cache_test.dart
@@ -147,6 +147,26 @@ void main() {
 
       expect(await cache.get('long'), equals('value'));
     });
+
+    test('toString returns live entries and omits expired entries', () async {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+        alertConfig: config,
+      );
+      addTearDown(cache.dispose);
+
+      await cache.set('expired', 'old', ttl: const Duration(seconds: 5));
+      await cache.set('live', 'new');
+      fakeNow = fakeNow.add(const Duration(seconds: 6));
+
+      final cacheString = cache.toString();
+
+      expect(cacheString, contains('live'));
+      expect(cacheString, contains('new'));
+      expect(cacheString, isNot(contains('expired')));
+      expect(cacheString, isNot(contains('old')));
+    });
   });
 
   group('MonitoredTTLCache - eviction metrics', () {
@@ -238,6 +258,30 @@ void main() {
 
   group('MonitoredTTLCache - lifecycle', () {
     final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test(
+      'background sweep removes expired entries and records evictions',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 10),
+          sweepInterval: const Duration(milliseconds: 5),
+          clock: fakeClock,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('key', 'value');
+        fakeNow = fakeNow.add(const Duration(seconds: 11));
+
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+
+        expect(await cache.getKeys(), isEmpty);
+        expect(
+          cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+          equals(1),
+        );
+      },
+    );
 
     test('clear removes entries without resetting metrics', () async {
       final cache = MonitoredTTLCache<String, String>(

--- a/test/caches/monitored_ttl_cache_test.dart
+++ b/test/caches/monitored_ttl_cache_test.dart
@@ -1,0 +1,273 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  DateTime fakeNow = DateTime(2024, 1, 1);
+  DateTime fakeClock() => fakeNow;
+
+  setUp(() {
+    fakeNow = DateTime(2024, 1, 1);
+  });
+
+  group('MonitoredTTLCache - constructor validation', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('throws ArgumentError for zero ttl', () {
+      expect(
+        () => MonitoredTTLCache<String, String>(
+          ttl: Duration.zero,
+          alertConfig: config,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for negative ttl', () {
+      expect(
+        () => MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: -1),
+          alertConfig: config,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for zero maxSize', () {
+      expect(
+        () => MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 10),
+          maxSize: 0,
+          alertConfig: config,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for zero sweepInterval', () {
+      expect(
+        () => MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 10),
+          sweepInterval: Duration.zero,
+          alertConfig: config,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+      'set() throws ArgumentError for zero per-entry ttl override',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 10),
+          clock: fakeClock,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await expectLater(
+          () => cache.set('key', 'value', ttl: Duration.zero),
+          throwsArgumentError,
+        );
+      },
+    );
+  });
+
+  group('MonitoredTTLCache - TTL behavior', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('stored value is returned before expiry and records a hit', () async {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+        alertConfig: config,
+      );
+      addTearDown(cache.dispose);
+
+      await cache.set('key', 'value');
+      fakeNow = fakeNow.add(const Duration(seconds: 9));
+
+      expect(await cache.get('key'), equals('value'));
+      expect(cache.metrics.hits, equals(1));
+      expect(cache.metrics.misses, equals(0));
+    });
+
+    test(
+      'expired entry is removed on get and records a miss and eviction',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 10),
+          clock: fakeClock,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('key', 'value');
+        fakeNow = fakeNow.add(const Duration(seconds: 11));
+
+        expect(await cache.get('key'), isNull);
+        expect(await cache.getKeys(), isNot(contains('key')));
+        expect(cache.metrics.hits, equals(0));
+        expect(cache.metrics.misses, equals(1));
+        expect(
+          cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+          equals(1),
+        );
+      },
+    );
+
+    test(
+      'stored null remains present until expiry and records a hit',
+      () async {
+        final cache = MonitoredTTLCache<String, String?>(
+          ttl: const Duration(seconds: 10),
+          clock: fakeClock,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('key', null);
+
+        expect(await cache.get('key'), isNull);
+        expect(await cache.getKeys(), contains('key'));
+        expect(cache.metrics.hits, equals(1));
+        expect(cache.metrics.misses, equals(0));
+      },
+    );
+
+    test('per-entry ttl overrides global ttl', () async {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 5),
+        clock: fakeClock,
+        alertConfig: config,
+      );
+      addTearDown(cache.dispose);
+
+      await cache.set('long', 'value', ttl: const Duration(seconds: 20));
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+
+      expect(await cache.get('long'), equals('value'));
+    });
+  });
+
+  group('MonitoredTTLCache - eviction metrics', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test(
+      'capacity eviction removes oldest live entry and records eviction',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 60),
+          maxSize: 2,
+          clock: fakeClock,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('a', '1');
+        await cache.set('b', '2');
+        await cache.set('c', '3');
+
+        expect(await cache.get('a'), isNull);
+        expect(await cache.get('b'), equals('2'));
+        expect(await cache.get('c'), equals('3'));
+        expect(
+          cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+          equals(1),
+        );
+      },
+    );
+
+    test(
+      'expired entries removed during capacity check record evictions',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 5),
+          maxSize: 2,
+          clock: fakeClock,
+          alertConfig: config,
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('a', '1');
+        await cache.set('b', '2');
+        fakeNow = fakeNow.add(const Duration(seconds: 10));
+        await cache.set('c', '3');
+
+        expect(await cache.getKeys(), equals(['c']));
+        expect(
+          cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+          equals(2),
+        );
+      },
+    );
+
+    test('remove existing key records eviction', () async {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+        alertConfig: config,
+      );
+      addTearDown(cache.dispose);
+
+      await cache.set('key', 'value');
+      await cache.remove('key');
+
+      expect(await cache.get('key'), isNull);
+      expect(
+        cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+        equals(1),
+      );
+    });
+
+    test('remove missing key does not record eviction', () async {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+        alertConfig: config,
+      );
+      addTearDown(cache.dispose);
+
+      await cache.remove('missing');
+
+      expect(
+        cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+        equals(0),
+      );
+    });
+  });
+
+  group('MonitoredTTLCache - lifecycle', () {
+    final config = CacheAlertConfig(notifyCallback: (_) {});
+
+    test('clear removes entries without resetting metrics', () async {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+        alertConfig: config,
+      );
+      addTearDown(cache.dispose);
+
+      await cache.set('key', 'value');
+      await cache.get('key');
+      await cache.clear();
+
+      expect(await cache.getKeys(), isEmpty);
+      expect(cache.metrics.hits, equals(1));
+    });
+
+    test('dispose implements Disposable and is idempotent', () {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        sweepInterval: const Duration(seconds: 60),
+        clock: fakeClock,
+        alertConfig: config,
+      );
+
+      expect(cache, isA<Disposable>());
+      expect(() {
+        cache.dispose();
+        cache.dispose();
+      }, returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## PR Summary

Adds a monitored TTL cache variant so TTL-based expiry can be used with the same metrics, dashboard, and alerting workflow as the other monitored cache implementations.

### Bugfix | Feature | Documentation Update | Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [ ] Release

### Fix / Feature Details

- **Issue:** `TTLCache` was a primary cache strategy, but it did not have a monitored counterpart. Users who wanted TTL expiry could not use the built-in hit/miss metrics, latency tracking, eviction metrics, dashboard snapshots, or alert thresholds with that policy.
- **Fix / Feature:** Added `MonitoredTTLCache` with TTL expiry, optional capacity limits, optional background sweeping, per-entry TTL overrides, alert configuration, nullable-value hit tracking, and eviction recording for expiry, capacity, and manual removals.

### Related Issue

N/A

---

## Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests

```sh
/Users/yotahara/fvm/versions/stable/bin/dart format lib/src/caches/monitored_ttl_cache.dart lib/cacherine.dart test/caches/monitored_ttl_cache_test.dart
/Users/yotahara/fvm/versions/stable/bin/dart analyze
/Users/yotahara/fvm/versions/stable/bin/dart test test/caches/monitored_ttl_cache_test.dart
/Users/yotahara/fvm/versions/stable/bin/dart test
```

---

## Documentation Update

### Documentation Changes

- [x] Updated README
- [x] Updated API reference
- [x] Updated TTL cache guide
- [x] Updated CHANGELOG

### Additional Notes

- `MonitoredTTLCache` records expired-entry removals as eviction events, including lazy expiry during `get()` and expired-entry cleanup during capacity checks.
- No dependency changes were required.

---

## Release Checklist

### Release Checklist

- [ ] Bump version in `pubspec.yaml`
- [x] Update `CHANGELOG.md` with release notes
- [x] Update `README.md` if necessary
- [x] Run `dart analyze` to ensure no issues
- [x] Run `dart test` to confirm all tests pass
- [ ] Ensure all dependencies are up to date
- [ ] Tag the release commit after merging
