### PR TITLE
Add containsKey API to cache implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Features
 
 - **MonitoredTTLCache**: Added a monitored TTL cache variant with hit/miss and latency metrics, eviction tracking for expiry/capacity/manual removals, alert support, and the same TTL configuration options as `TTLCache`.
+- **containsKey() API**: Added `containsKey()` to simple, async-safe, monitored, and TTL cache variants so callers can distinguish stored `null` values from missing keys without mutating eviction state.
 
 ## 2.0.1 - LFU Performance Improvements, Bug Fixes, and Maintenance
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Whether you need a simple synchronous cache or an async-compatible solution that
   — [Learn more](doc/monitored_cache.md)
 - **MonitoredTTLCache** (TTL-based expiry with the same monitoring metrics and alerts as other monitored cache variants)
 - **CacheStatsDashboard** (Wraps a MonitoredCache's metrics to provide point-in-time snapshots and periodic streams; `formatDashboard()` renders a Unicode terminal panel)
+- **`containsKey()` support** (distinguishes missing keys from stored `null` values without changing cache eviction state)
 - **Simple versions (e.g., SimpleFIFOCache) for synchronous usage, and standard versions that serialize concurrent async calls within the same isolate**
 
 ## Installation
@@ -155,7 +156,7 @@ void main() async {
 
 The standard and monitored cache variants use `Future` APIs and an internal lock to serialize concurrent async calls on the same cache instance within the same isolate. They are not shared-memory synchronization primitives across Dart isolates.
 
-`get()` returns `null` when a key is absent. Because the current API does not expose `containsKey()` or an entry wrapper, storing nullable values such as `Cache<String, String?>` is not supported: a stored `null` cannot be distinguished from a missing key.
+`get()` returns `null` when a key is absent. Use `containsKey()` to distinguish a missing key from a stored `null` value, such as `Cache<String, String?>`. `containsKey()` does not update LRU/MRU/LFU access state, does not remove entries from EphemeralFIFO caches, and does not record monitored cache hit/miss metrics. For TTL caches, expired entries return `false`.
 
 `toString()` is synchronous. It returns a point-in-time representation of the cache contents and should be treated as diagnostic output, not as a synchronized cache operation.
 

--- a/doc/ttl_cache.md
+++ b/doc/ttl_cache.md
@@ -44,7 +44,15 @@ When `maxSize` is specified, `set()` enforces a cap on the number of **live** (n
 2. If the key exists but its TTL has elapsed → remove the entry, return `null` (lazy eviction).
 3. If the key exists and is still within its TTL → return the value.
 
-### 3.2 Data Insertion (`set` operation)
+### 3.2 Existence Check (`containsKey` operation)
+
+1. If the key does not exist → return `false`.
+2. If the key exists but its TTL has elapsed → remove the entry, return `false`.
+3. If the key exists and is still within its TTL → return `true`.
+
+Use `containsKey()` to distinguish a missing key from a stored `null` value.
+
+### 3.3 Data Insertion (`set` operation)
 
 1. If the key already exists, remove it first (so the refreshed entry gets a new insertion timestamp, affecting FIFO order).
 2. If `maxSize` is set and the number of live entries would reach `maxSize`:
@@ -52,7 +60,7 @@ When `maxSize` is specified, `set()` enforces a cap on the number of **live** (n
    b. If still at or over capacity, remove the oldest-inserted live entry (FIFO).
 3. Store the entry with expiry = `clock() + ttl`.
 
-### 3.3 Example: TTLCache Operations and State Changes
+### 3.4 Example: TTLCache Operations and State Changes
 
 Setup: `TTLCache(ttl: Duration(seconds: 10), maxSize: 3)`  
 (clock starts at t=0)
@@ -131,6 +139,7 @@ cache.dispose();
 |--------|-------------|
 | `set(K key, V value, {Duration? ttl})` | Store an entry. `ttl:` overrides the global TTL for this entry. |
 | `get(K key)` | Retrieve a value, or `null` if missing or expired (lazy eviction). |
+| `containsKey(K key)` | Return whether a non-expired entry exists for the key. Expired entries are removed and return `false`. |
 | `getKeys()` | Return only keys whose TTL has not elapsed. |
 | `remove(K key)` | Remove a single entry; no-op if absent. |
 | `clear()` | Remove all entries. |

--- a/lib/src/caches/ephemeral_fifo_cache.dart
+++ b/lib/src/caches/ephemeral_fifo_cache.dart
@@ -57,6 +57,14 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Checks whether [key] exists in the cache without removing it.
+  ///
+  /// **This method is async-safe.**
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If the key already exists, **the value is updated**.

--- a/lib/src/caches/fifo_cache.dart
+++ b/lib/src/caches/fifo_cache.dart
@@ -50,6 +50,14 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Checks whether [key] exists in the cache.
+  ///
+  /// **This method is async-safe.**
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **the value is updated**.

--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -92,6 +92,14 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Checks whether [key] exists in the cache without incrementing its frequency.
+  ///
+  /// **This method is async-safe.**
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _keyMap.containsKey(key));
+  }
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **the value is updated**,

--- a/lib/src/caches/lru_cache.dart
+++ b/lib/src/caches/lru_cache.dart
@@ -53,6 +53,14 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Checks whether [key] exists in the cache without updating LRU order.
+  ///
+  /// **This method is async-safe.**
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **its value is updated**

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -88,6 +88,14 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
     }, found: () => found);
   }
 
+  /// Checks whether [key] exists in the cache without removing it or recording metrics.
+  ///
+  /// **This method is async-safe**.
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// Stores the specified key and value in the cache.
   ///
   /// - If the key already exists, `set()` will **update its value** without changing its position.

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -90,6 +90,14 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
     }, found: () => found);
   }
 
+  /// Checks whether [key] exists in the cache without recording hit/miss metrics.
+  ///
+  /// **This method is async-safe**.
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// Stores the specified key and value in the cache.
   ///
   /// - If the key already exists, `set()` will **update its value** without changing its position.

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -121,6 +121,14 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
     }, found: () => found);
   }
 
+  /// Checks whether [key] exists without incrementing frequency or recording metrics.
+  ///
+  /// **This method is async-safe**.
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _keyMap.containsKey(key));
+  }
+
   /// Stores the specified key and value in the cache.
   ///
   /// - If the key already exists, `set()` will **update its value** without resetting its usage count.

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -93,6 +93,14 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
     }, found: () => found);
   }
 
+  /// Checks whether [key] exists without updating LRU order or recording metrics.
+  ///
+  /// **This method is async-safe**.
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// Stores the specified key and value in the cache.
   ///
   /// - If the key already exists, `set()` will **update its value** and move it to the end (LRU policy).

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -93,6 +93,14 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
     }, found: () => found);
   }
 
+  /// Checks whether [key] exists without updating MRU order or recording metrics.
+  ///
+  /// **This method is async-safe**.
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// Stores the specified key and value in the cache.
   ///
   /// - If the key already exists, `set()` will **update its value** and move it to the most recently used position.

--- a/lib/src/caches/monitored_ttl_cache.dart
+++ b/lib/src/caches/monitored_ttl_cache.dart
@@ -145,6 +145,20 @@ class MonitoredTTLCache<K, V> extends ThreadSafeCache<K, V>
     }, found: () => found);
   }
 
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() {
+      final entry = _cache[key];
+      if (entry == null) return false;
+      if (!entry.expiry.isAfter(_clock())) {
+        _cache.remove(key);
+        metrics.recordEviction();
+        return false;
+      }
+      return true;
+    });
+  }
+
   /// Stores [key]/[value] in the cache.
   ///
   /// - [ttl]: Per-entry TTL override. When omitted, the global TTL is used.

--- a/lib/src/caches/mru_cache.dart
+++ b/lib/src/caches/mru_cache.dart
@@ -55,6 +55,14 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
     });
   }
 
+  /// Checks whether [key] exists in the cache without updating MRU order.
+  ///
+  /// **This method is async-safe.**
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() => _cache.containsKey(key));
+  }
+
   /// **Stores the specified key-value pair in the cache.**
   ///
   /// - If `set()` is called on an existing key, **its value is updated**,

--- a/lib/src/caches/simple_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/simple_ephemeral_fifo_cache.dart
@@ -45,6 +45,12 @@ class SimpleEphemeralFIFOCache<K, V> extends SimpleCache<K, V> {
     return _cache.remove(key); // Remove after retrieval
   }
 
+  /// Checks whether [key] exists in the cache without removing it.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  bool containsKey(K key) => _cache.containsKey(key);
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **its value is updated**.

--- a/lib/src/caches/simple_fifo_cache.dart
+++ b/lib/src/caches/simple_fifo_cache.dart
@@ -44,6 +44,12 @@ class SimpleFIFOCache<K, V> extends SimpleCache<K, V> {
     return _cache[key];
   }
 
+  /// Checks whether [key] exists in the cache.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  bool containsKey(K key) => _cache.containsKey(key);
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **its value is updated**.

--- a/lib/src/caches/simple_lfu_cache.dart
+++ b/lib/src/caches/simple_lfu_cache.dart
@@ -84,6 +84,12 @@ class SimpleLFUCache<K, V> extends SimpleCache<K, V> {
     return node.value;
   }
 
+  /// Checks whether [key] exists in the cache without incrementing its frequency.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  bool containsKey(K key) => _keyMap.containsKey(key);
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **its value is updated**,

--- a/lib/src/caches/simple_lru_cache.dart
+++ b/lib/src/caches/simple_lru_cache.dart
@@ -47,6 +47,12 @@ class SimpleLRUCache<K, V> extends SimpleCache<K, V> {
     return value;
   }
 
+  /// Checks whether [key] exists in the cache without updating LRU order.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  bool containsKey(K key) => _cache.containsKey(key);
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **its value is updated**

--- a/lib/src/caches/simple_mru_cache.dart
+++ b/lib/src/caches/simple_mru_cache.dart
@@ -48,6 +48,12 @@ class SimpleMRUCache<K, V> extends SimpleCache<K, V> {
     return value;
   }
 
+  /// Checks whether [key] exists in the cache without updating MRU order.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  bool containsKey(K key) => _cache.containsKey(key);
+
   /// Stores the specified key-value pair in the cache.
   ///
   /// - If `set()` is called on an existing key, **its value is updated**,

--- a/lib/src/caches/ttl_cache.dart
+++ b/lib/src/caches/ttl_cache.dart
@@ -106,6 +106,19 @@ class TTLCache<K, V> extends ThreadSafeCache<K, V> implements Disposable {
     });
   }
 
+  @override
+  Future<bool> containsKey(K key) async {
+    return await _lock.synchronized(() {
+      final entry = _cache[key];
+      if (entry == null) return false;
+      if (!entry.expiry.isAfter(_clock())) {
+        _cache.remove(key);
+        return false;
+      }
+      return true;
+    });
+  }
+
   /// Stores [key]/[value] in the cache.
   ///
   /// - [ttl]: Per-entry TTL override. When omitted, the global TTL is used.

--- a/lib/src/interfaces/simple_cache.dart
+++ b/lib/src/interfaces/simple_cache.dart
@@ -19,6 +19,17 @@ abstract class SimpleCache<K, V> {
   /// **Returns:** The value associated with the key, or `null`.
   V? get(K key);
 
+  /// **Checks whether the specified key is currently stored in the cache.**
+  ///
+  /// This method distinguishes a present key with a `null` value from an
+  /// absent key.
+  ///
+  /// **Arguments:**
+  /// - `key`: The key to check.
+  ///
+  /// **Returns:** `true` if the key exists, otherwise `false`.
+  bool containsKey(K key);
+
   /// **Stores the specified key-value pair in the cache.**
   ///
   /// - If the key already exists, its corresponding value is updated.

--- a/lib/src/interfaces/thread_safe_cache.dart
+++ b/lib/src/interfaces/thread_safe_cache.dart
@@ -21,6 +21,17 @@ abstract class ThreadSafeCache<K, V> {
   /// **Returns:** `Future<V?>` (The value associated with the key, or `null`).
   Future<V?> get(K key);
 
+  /// **Checks whether the specified key is currently stored in the cache.**
+  ///
+  /// This method distinguishes a present key with a `null` value from an
+  /// absent key.
+  ///
+  /// **Arguments:**
+  /// - `key`: The key to check.
+  ///
+  /// **Returns:** `Future<bool>` (`true` if the key exists, otherwise `false`).
+  Future<bool> containsKey(K key);
+
   /// **Stores the specified key-value pair in the cache (asynchronously).**
   ///
   /// - If the key already exists, its corresponding value is updated.

--- a/test/caches/contains_key_test.dart
+++ b/test/caches/contains_key_test.dart
@@ -1,0 +1,215 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SimpleCache containsKey()', () {
+    final factories = <String, SimpleCache<String, String?> Function()>{
+      'SimpleFIFOCache': () => SimpleFIFOCache<String, String?>(2),
+      'SimpleEphemeralFIFOCache': () =>
+          SimpleEphemeralFIFOCache<String, String?>(2),
+      'SimpleLRUCache': () => SimpleLRUCache<String, String?>(2),
+      'SimpleMRUCache': () => SimpleMRUCache<String, String?>(2),
+      'SimpleLFUCache': () => SimpleLFUCache<String, String?>(2),
+    };
+
+    for (final entry in factories.entries) {
+      test('${entry.key} distinguishes stored null from missing key', () {
+        final cache = entry.value();
+
+        cache.set('present', null);
+
+        expect(cache.get('present'), isNull);
+        if (entry.key == 'SimpleEphemeralFIFOCache') {
+          cache.set('present', null);
+        }
+        expect(cache.containsKey('present'), isTrue);
+        expect(cache.containsKey('missing'), isFalse);
+
+        cache.remove('present');
+
+        expect(cache.containsKey('present'), isFalse);
+      });
+    }
+  });
+
+  group('ThreadSafeCache containsKey()', () {
+    final factories = <String, ThreadSafeCache<String, String?> Function()>{
+      'FIFOCache': () => FIFOCache<String, String?>(2),
+      'EphemeralFIFOCache': () => EphemeralFIFOCache<String, String?>(2),
+      'LRUCache': () => LRUCache<String, String?>(2),
+      'MRUCache': () => MRUCache<String, String?>(2),
+      'LFUCache': () => LFUCache<String, String?>(2),
+    };
+
+    for (final entry in factories.entries) {
+      test('${entry.key} distinguishes stored null from missing key', () async {
+        final cache = entry.value();
+
+        await cache.set('present', null);
+
+        expect(await cache.get('present'), isNull);
+        if (entry.key == 'EphemeralFIFOCache') {
+          await cache.set('present', null);
+        }
+        expect(await cache.containsKey('present'), isTrue);
+        expect(await cache.containsKey('missing'), isFalse);
+
+        await cache.remove('present');
+
+        expect(await cache.containsKey('present'), isFalse);
+      });
+    }
+  });
+
+  group('Monitored caches containsKey()', () {
+    final factories = <String, ThreadSafeCache<String, String?> Function()>{
+      'MonitoredFIFOCache': () =>
+          MonitoredFIFOCache<String, String?>(maxSize: 2),
+      'MonitoredEphemeralFIFOCache': () =>
+          MonitoredEphemeralFIFOCache<String, String?>(maxSize: 2),
+      'MonitoredLRUCache': () => MonitoredLRUCache<String, String?>(maxSize: 2),
+      'MonitoredMRUCache': () => MonitoredMRUCache<String, String?>(maxSize: 2),
+      'MonitoredLFUCache': () => MonitoredLFUCache<String, String?>(maxSize: 2),
+    };
+
+    for (final entry in factories.entries) {
+      test('${entry.key} distinguishes stored null from missing key', () async {
+        final cache = entry.value();
+        addTearDown(() {
+          if (cache case Disposable disposable) {
+            disposable.dispose();
+          }
+        });
+
+        await cache.set('present', null);
+
+        expect(await cache.get('present'), isNull);
+        if (entry.key == 'MonitoredEphemeralFIFOCache') {
+          await cache.set('present', null);
+        }
+        expect(await cache.containsKey('present'), isTrue);
+        expect(await cache.containsKey('missing'), isFalse);
+
+        await cache.remove('present');
+
+        expect(await cache.containsKey('present'), isFalse);
+      });
+    }
+
+    test(
+      'MonitoredFIFOCache containsKey() does not record hits or misses',
+      () async {
+        final cache = MonitoredFIFOCache<String, String?>(maxSize: 2);
+        addTearDown(cache.dispose);
+
+        await cache.set('present', null);
+
+        expect(await cache.containsKey('present'), isTrue);
+        expect(await cache.containsKey('missing'), isFalse);
+        expect(cache.metrics.hits, equals(0));
+        expect(cache.metrics.misses, equals(0));
+      },
+    );
+  });
+
+  group('containsKey() policy side effects', () {
+    test(
+      'EphemeralFIFOCache containsKey() does not remove the entry',
+      () async {
+        final cache = EphemeralFIFOCache<String, String>(2);
+
+        await cache.set('a', 'A');
+
+        expect(await cache.containsKey('a'), isTrue);
+        expect(await cache.get('a'), equals('A'));
+        expect(await cache.containsKey('a'), isFalse);
+      },
+    );
+
+    test('LRUCache containsKey() does not update recency', () async {
+      final cache = LRUCache<String, String>(2);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+      expect(await cache.containsKey('a'), isTrue);
+      await cache.set('c', 'C');
+
+      expect(await cache.containsKey('a'), isFalse);
+      expect(await cache.containsKey('b'), isTrue);
+      expect(await cache.containsKey('c'), isTrue);
+    });
+
+    test('MRUCache containsKey() does not update recency', () async {
+      final cache = MRUCache<String, String>(2);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+      expect(await cache.containsKey('a'), isTrue);
+      await cache.set('c', 'C');
+
+      expect(await cache.containsKey('a'), isTrue);
+      expect(await cache.containsKey('b'), isFalse);
+      expect(await cache.containsKey('c'), isTrue);
+    });
+
+    test('LFUCache containsKey() does not increment frequency', () async {
+      final cache = LFUCache<String, String>(2);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+      expect(await cache.containsKey('a'), isTrue);
+      await cache.set('c', 'C');
+
+      expect(await cache.containsKey('a'), isFalse);
+      expect(await cache.containsKey('b'), isTrue);
+      expect(await cache.containsKey('c'), isTrue);
+    });
+  });
+
+  group('TTL containsKey()', () {
+    DateTime now = DateTime(2024, 1, 1);
+    DateTime clock() => now;
+
+    setUp(() {
+      now = DateTime(2024, 1, 1);
+    });
+
+    test('TTLCache returns false for expired keys', () async {
+      final cache = TTLCache<String, String?>(
+        ttl: const Duration(seconds: 10),
+        clock: clock,
+      );
+
+      await cache.set('present', null);
+
+      expect(await cache.containsKey('present'), isTrue);
+
+      now = now.add(const Duration(seconds: 11));
+
+      expect(await cache.containsKey('present'), isFalse);
+      expect(await cache.getKeys(), isNot(contains('present')));
+    });
+
+    test('MonitoredTTLCache returns false for expired keys', () async {
+      final cache = MonitoredTTLCache<String, String?>(
+        ttl: const Duration(seconds: 10),
+        clock: clock,
+      );
+      addTearDown(cache.dispose);
+
+      await cache.set('present', null);
+
+      expect(await cache.containsKey('present'), isTrue);
+
+      now = now.add(const Duration(seconds: 11));
+
+      expect(await cache.containsKey('present'), isFalse);
+      expect(cache.metrics.hits, equals(0));
+      expect(cache.metrics.misses, equals(0));
+      expect(
+        cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+        equals(1),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## PR Summary

Adds `containsKey()` across the cache APIs so callers can distinguish a missing key from a stored `null` value without mutating cache policy state.

### Bugfix | Feature | Documentation Update | Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [ ] Release

### Fix / Feature Details

- **Issue:** `get()` returns `null` for both missing keys and stored `null` values, so nullable cache values could not be reliably distinguished through the public API.
- **Fix / Feature:** Added `containsKey()` to `SimpleCache`, `ThreadSafeCache`, and all simple, async-safe, monitored, and TTL cache variants.
- **Behavior:** `containsKey()` is a read-only existence check for eviction policies: it does not update LRU/MRU order, does not increment LFU frequency, does not remove entries from EphemeralFIFO caches, and does not record monitored cache hit/miss metrics.
- **TTL behavior:** TTL caches return `false` for expired entries and remove those expired entries lazily during the check.

### Related Issue

N/A

---

## Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests

```sh
/Users/yotahara/fvm/versions/stable/bin/dart analyze
/Users/yotahara/fvm/versions/stable/bin/dart test test/caches/contains_key_test.dart
/Users/yotahara/fvm/versions/stable/bin/dart test
```

---

## Documentation Update

### Documentation Changes

- [x] Updated README
- [x] Updated API reference
- [x] Updated TTL cache guide
- [x] Updated CHANGELOG

### Additional Notes

- `containsKey()` enables nullable value use cases such as `Cache<String, String?>` while keeping `get()` behavior unchanged.
- `MonitoredTTLCache.containsKey()` records expired-entry cleanup as an eviction event but does not record hit/miss metrics.
- No dependency changes were required.

---

## Release Checklist

### Release Checklist

- [ ] Bump version in `pubspec.yaml`
- [x] Update `CHANGELOG.md` with release notes
- [x] Update `README.md` if necessary
- [x] Run `dart analyze` to ensure no issues
- [x] Run `dart test` to confirm all tests pass
- [ ] Ensure all dependencies are up to date
- [ ] Tag the release commit after merging
