### PR TITLE
Add SimpleTTLCache and runnable examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+### New Features
+
+- **SimpleTTLCache**: Added a synchronous TTL cache variant with global and per-entry TTL, lazy expiry, `containsKey()`, optional `maxSize`, and FIFO capacity eviction.
+
+### Documentation
+
+- Added runnable package examples covering `SimpleTTLCache`, `TTLCache`, and monitored cache dashboard snapshots.
+- Documented synchronous TTL usage in the README and TTL guide.
+
 ## 2.1.0 - Monitored TTL Cache, containsKey API, and Monitoring Improvements
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Whether you need a simple synchronous cache or an async-compatible solution that
   — [Learn more](doc/lfu_cache.md)
 - **TTL** (Time-To-Live — entries auto-expire after a configurable duration; optional per-entry TTL override and background sweep)
   — [Learn more](doc/ttl_cache.md)
+- **SimpleTTLCache** (synchronous TTL cache for single-threaded usage)
 - **MonitoredCache** (Includes performance monitoring with hit/miss rates, latency, and eviction alerts)
   — [Learn more](doc/monitored_cache.md)
 - **MonitoredTTLCache** (TTL-based expiry with the same monitoring metrics and alerts as other monitored cache variants)
@@ -70,6 +71,24 @@ void main() {
   final cache = SimpleFIFOCache<String, String>(maxSize: 5);
   cache.set('key1', 'value1');
   print(cache.get('key1')); // 'value1'
+}
+```
+
+For synchronous single-threaded usage, use `SimpleTTLCache`:
+
+```Dart
+import 'package:cacherine/cacherine.dart';
+
+void main() {
+  final cache = SimpleTTLCache<String, String>(
+    ttl: const Duration(minutes: 5),
+    maxSize: 100,
+  );
+
+  cache.set('token', 'abc123');
+  cache.set('rate', '42', ttl: const Duration(seconds: 30));
+
+  print(cache.get('token')); // 'abc123' (if within TTL)
 }
 ```
 
@@ -161,6 +180,13 @@ The standard and monitored cache variants use `Future` APIs and an internal lock
 `toString()` is synchronous. It returns a point-in-time representation of the cache contents and should be treated as diagnostic output, not as a synchronized cache operation.
 
 ## API Reference
+
+- [SimpleFIFOCache<K, V>](lib/src/caches/simple_fifo_cache.dart): Synchronous FIFO-based cache
+- [SimpleEphemeralFIFOCache<K, V>](lib/src/caches/simple_ephemeral_fifo_cache.dart): Synchronous Ephemeral FIFO cache
+- [SimpleLRUCache<K, V>](lib/src/caches/simple_lru_cache.dart): Synchronous LRU-based cache
+- [SimpleMRUCache<K, V>](lib/src/caches/simple_mru_cache.dart): Synchronous MRU-based cache
+- [SimpleLFUCache<K, V>](lib/src/caches/simple_lfu_cache.dart): Synchronous LFU-based cache
+- [SimpleTTLCache<K, V>](lib/src/caches/simple_ttl_cache.dart): Synchronous TTL-based cache
 
 - [FIFOCache<K, V>](lib/src/caches/fifo_cache.dart): FIFO-based cache
 - [EphemeralFIFOCache<K, V>](lib/src/caches/ephemeral_fifo_cache.dart): FIFO-based cache where the key is removed after being accessed (One-Time Read Cache)

--- a/doc/ttl_cache.md
+++ b/doc/ttl_cache.md
@@ -23,6 +23,8 @@ A `TTLCache` stores each entry together with an **expiry timestamp** computed at
 
 Lazy eviction is the correctness guarantee — the cache is always accurate. The background sweep is purely a memory optimisation for use cases where keys may expire without ever being accessed again.
 
+`SimpleTTLCache` provides the same expiry, per-entry TTL, `containsKey()`, and optional `maxSize` behavior for synchronous single-threaded usage. It does not start a background sweep timer and does not implement `Disposable`; expired entries are removed lazily or ignored by read APIs.
+
 ### 2.3 Global TTL vs Per-Entry TTL Override
 
 ```
@@ -90,7 +92,23 @@ Setup: `TTLCache(ttl: Duration(seconds: 10), maxSize: 3)`
    |-----|--------|
    | D   | t=21   |
 
-## 4. Lifecycle and Disposal
+## 4. Synchronous Usage
+
+Use `SimpleTTLCache` when you need a synchronous cache and do not need async call serialization:
+
+```dart
+final cache = SimpleTTLCache<String, String>(
+  ttl: const Duration(minutes: 5),
+  maxSize: 100,
+);
+
+cache.set('token', 'abc123');
+cache.set('rate', '42', ttl: const Duration(seconds: 30));
+
+print(cache.get('token'));
+```
+
+## 5. Lifecycle and Disposal
 
 `TTLCache` implements `Disposable`. When a `sweepInterval` is configured, a background `Timer.periodic` is started in the constructor. Call `dispose()` to cancel it and stop further sweeps:
 
@@ -107,7 +125,7 @@ cache.dispose(); // cancel sweep timer
 
 `dispose()` is idempotent — calling it multiple times is safe. After `dispose()`, `get()` and `set()` continue to work; only the background sweep stops.
 
-## 5. Monitoring
+## 6. Monitoring
 
 Use `MonitoredTTLCache` when you need TTL expiry together with `CacheMetrics`,
 `CacheStatsDashboard`, or alert thresholds. It supports the same TTL options as
@@ -133,7 +151,7 @@ print(snapshot.hitRate);
 cache.dispose();
 ```
 
-## 6. API Reference
+## 7. API Reference
 
 | Method | Description |
 |--------|-------------|
@@ -143,18 +161,18 @@ cache.dispose();
 | `getKeys()` | Return only keys whose TTL has not elapsed. |
 | `remove(K key)` | Remove a single entry; no-op if absent. |
 | `clear()` | Remove all entries. |
-| `dispose()` | Cancel the background sweep timer. Idempotent. |
+| `dispose()` | Cancel the background sweep timer. Idempotent. Supported by `TTLCache` and `MonitoredTTLCache`; not supported by `SimpleTTLCache`. |
 
-## 7. Constructor Parameters
+## 8. Constructor Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `ttl` | `Duration` | Yes | Global TTL applied to all `set()` calls. |
 | `maxSize` | `int?` | No | Maximum number of live entries. No limit if omitted. |
-| `sweepInterval` | `Duration?` | No | Interval for background expired-entry removal. No sweep if omitted. |
+| `sweepInterval` | `Duration?` | No | Interval for background expired-entry removal. No sweep if omitted. Supported by `TTLCache` and `MonitoredTTLCache`; not supported by `SimpleTTLCache`. |
 | `clock` | `DateTime Function()?` | No | Time source. Defaults to `DateTime.now`. Inject a fake clock in tests. |
 
-## 8. Suitable Use Cases
+## 9. Suitable Use Cases
 
 TTL Cache is well-suited for data with a natural validity window:
 
@@ -163,7 +181,7 @@ TTL Cache is well-suited for data with a natural validity window:
 - **Computed values with bounded validity**: Cache expensive computations that are known to be stale after a fixed interval (e.g., exchange rates, configuration snapshots).
 - **Rate-limiting state**: Track per-key counters that should reset after a time window.
 
-## 9. Choosing Between TTLCache and Capacity-Based Caches
+## 10. Choosing Between TTLCache and Capacity-Based Caches
 
 | | Capacity-based (FIFO/LRU/etc.) | TTLCache |
 |-|-------------------------------|----------|

--- a/example/cacherine_example.dart
+++ b/example/cacherine_example.dart
@@ -1,1 +1,49 @@
+import 'package:cacherine/cacherine.dart';
 
+Future<void> main() async {
+  synchronousTTLExample();
+  await asyncTTLExample();
+  await monitoredCacheExample();
+}
+
+void synchronousTTLExample() {
+  final cache = SimpleTTLCache<String, String>(
+    ttl: const Duration(minutes: 5),
+    maxSize: 100,
+  );
+
+  cache.set('token', 'abc123');
+  cache.set('rate', '42', ttl: const Duration(seconds: 30));
+
+  print('SimpleTTLCache token: ${cache.get('token')}');
+  print('SimpleTTLCache has token: ${cache.containsKey('token')}');
+}
+
+Future<void> asyncTTLExample() async {
+  final cache = TTLCache<String, String>(
+    ttl: const Duration(minutes: 5),
+    maxSize: 100,
+  );
+
+  await cache.set('user:1', 'Ada');
+  await cache.set('session:1', 'active', ttl: const Duration(minutes: 1));
+
+  print('TTLCache user: ${await cache.get('user:1')}');
+
+  cache.dispose();
+}
+
+Future<void> monitoredCacheExample() async {
+  final cache = MonitoredLRUCache<String, String>(maxSize: 2);
+
+  await cache.set('a', 'first');
+  await cache.set('b', 'second');
+  await cache.get('a');
+  await cache.get('missing');
+
+  final dashboard = CacheStatsDashboard(cache.metrics);
+  final snapshot = dashboard.snapshot(const Duration(minutes: 1));
+
+  print(formatDashboard(snapshot));
+  cache.dispose();
+}

--- a/lib/cacherine.dart
+++ b/lib/cacherine.dart
@@ -17,6 +17,7 @@ export 'src/caches/simple_fifo_cache.dart';
 export 'src/caches/simple_lru_cache.dart';
 export 'src/caches/simple_mru_cache.dart';
 export 'src/caches/simple_lfu_cache.dart';
+export 'src/caches/simple_ttl_cache.dart';
 
 // Standard Caches
 export 'src/caches/ephemeral_fifo_cache.dart';

--- a/lib/src/caches/simple_ttl_cache.dart
+++ b/lib/src/caches/simple_ttl_cache.dart
@@ -1,0 +1,167 @@
+import 'dart:collection';
+
+import '../interfaces/simple_cache.dart';
+
+class _SimpleTTLEntry<V> {
+  final V value;
+  final DateTime expiry;
+
+  _SimpleTTLEntry(this.value, this.expiry);
+}
+
+/// **Non-thread-safe TTL (Time-To-Live) Cache**
+///
+/// Entries are automatically treated as absent once their TTL has elapsed.
+/// Expiry is checked lazily on [get] and [containsKey].
+///
+/// This class is designed for use in **single-threaded environments**
+/// or scenarios where **concurrent access is not required**.
+/// Since it is not thread-safe and does not perform synchronization,
+/// **use `TTLCache` if async-safe access is needed.**
+class SimpleTTLCache<K, V> extends SimpleCache<K, V> {
+  final Duration _globalTTL;
+  final int? _maxSize;
+  final DateTime Function() _clock;
+
+  final LinkedHashMap<K, _SimpleTTLEntry<V>> _cache = LinkedHashMap();
+
+  /// Creates a [SimpleTTLCache].
+  ///
+  /// - [ttl]: Default expiry duration for all entries stored via [set].
+  /// - [maxSize]: Optional capacity limit; the oldest-inserted live entry is
+  ///   evicted (FIFO) when the limit is exceeded.
+  /// - [clock]: Injectable time source for testing; defaults to [DateTime.now].
+  ///
+  /// **Throws [ArgumentError] if [ttl] is zero or negative.**
+  /// **Throws [ArgumentError] if [maxSize] is 0 or less.**
+  SimpleTTLCache({
+    required Duration ttl,
+    int? maxSize,
+    DateTime Function()? clock,
+  }) : _globalTTL = ttl,
+       _maxSize = maxSize,
+       _clock = clock ?? DateTime.now {
+    if (ttl <= Duration.zero) {
+      throw ArgumentError('ttl must be greater than zero.');
+    }
+    if (maxSize != null && maxSize <= 0) {
+      throw ArgumentError('maxSize must be greater than 0.');
+    }
+  }
+
+  bool _isExpired(_SimpleTTLEntry<V> entry) => !entry.expiry.isAfter(_clock());
+
+  void _removeExpiredEntries() {
+    final now = _clock();
+    _cache.removeWhere((_, entry) => !entry.expiry.isAfter(now));
+  }
+
+  void _evictIfNeeded() {
+    final maxSize = _maxSize;
+    if (maxSize == null || _cache.length < maxSize) return;
+
+    _removeExpiredEntries();
+    while (_cache.length >= maxSize) {
+      _cache.remove(_cache.keys.first);
+    }
+  }
+
+  /// Returns all non-expired keys currently stored in the cache.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  Iterable<K> getKeys() {
+    final now = _clock();
+    return _cache.entries
+        .where((e) => e.value.expiry.isAfter(now))
+        .map((e) => e.key)
+        .toList();
+  }
+
+  /// Retrieves the value associated with the specified key.
+  ///
+  /// - Returns `null` if the key does not exist or has expired.
+  /// - Removes expired entries lazily.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  V? get(K key) {
+    final entry = _cache[key];
+    if (entry == null) return null;
+    if (_isExpired(entry)) {
+      _cache.remove(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  /// Checks whether [key] exists and has not expired.
+  ///
+  /// Use this method to distinguish a present key with a `null` value from an
+  /// absent or expired key.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  bool containsKey(K key) {
+    final entry = _cache[key];
+    if (entry == null) return false;
+    if (_isExpired(entry)) {
+      _cache.remove(key);
+      return false;
+    }
+    return true;
+  }
+
+  /// Stores [key]/[value] in the cache.
+  ///
+  /// - [ttl]: Per-entry TTL override. When omitted, the global TTL is used.
+  /// - If the key already exists, its value and expiry are updated and its
+  ///   insertion order is refreshed (it becomes the newest entry for FIFO purposes).
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void set(K key, V value, {Duration? ttl}) {
+    if (ttl != null && ttl <= Duration.zero) {
+      throw ArgumentError('ttl must be greater than zero.');
+    }
+
+    _cache.remove(key);
+    _evictIfNeeded();
+    _cache[key] = _SimpleTTLEntry(value, _clock().add(ttl ?? _globalTTL));
+  }
+
+  /// Removes the entry with the given key from the cache.
+  ///
+  /// - If the key does not exist, this call is a no-op.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void remove(K key) {
+    _cache.remove(key);
+  }
+
+  /// Clears all data stored in the cache.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  void clear() {
+    _cache.clear();
+  }
+
+  /// Returns a string representation of the current live cache state.
+  ///
+  /// Expired entries are excluded from the returned representation.
+  ///
+  /// **This method is not thread-safe.**
+  @override
+  String toString() {
+    final liveEntries = <K, V>{};
+    final now = _clock();
+    for (final entry in _cache.entries) {
+      if (entry.value.expiry.isAfter(now)) {
+        liveEntries[entry.key] = entry.value.value;
+      }
+    }
+    return liveEntries.toString();
+  }
+}

--- a/test/caches/simple_ttl_cache_test.dart
+++ b/test/caches/simple_ttl_cache_test.dart
@@ -240,5 +240,16 @@ void main() {
 
       expect(cache.toString(), isNot(contains('a: 1')));
     });
+
+    test('toString() includes live entries', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+
+      expect(cache.toString(), contains('a: 1'));
+    });
   });
 }

--- a/test/caches/simple_ttl_cache_test.dart
+++ b/test/caches/simple_ttl_cache_test.dart
@@ -1,0 +1,244 @@
+import 'package:cacherine/src/caches/simple_ttl_cache.dart';
+import 'package:test/test.dart';
+
+void main() {
+  DateTime fakeNow = DateTime(2024);
+  DateTime fakeClock() => fakeNow;
+
+  setUp(() {
+    fakeNow = DateTime(2024);
+  });
+
+  group('SimpleTTLCache - Constructor validation', () {
+    test('throws ArgumentError for zero ttl', () {
+      expect(
+        () => SimpleTTLCache<String, String>(ttl: Duration.zero),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for negative ttl', () {
+      expect(
+        () => SimpleTTLCache<String, String>(ttl: const Duration(seconds: -1)),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for zero maxSize', () {
+      expect(
+        () => SimpleTTLCache<String, String>(
+          ttl: const Duration(seconds: 10),
+          maxSize: 0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('set() throws ArgumentError for invalid per-entry ttl', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      expect(
+        () => cache.set('key', 'value', ttl: Duration.zero),
+        throwsArgumentError,
+      );
+      expect(
+        () => cache.set('key', 'value', ttl: const Duration(seconds: -1)),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('SimpleTTLCache - Expiry', () {
+    test('entry is accessible before TTL elapses', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('key', 'value');
+      fakeNow = fakeNow.add(const Duration(seconds: 9));
+
+      expect(cache.get('key'), equals('value'));
+    });
+
+    test('entry expires after global TTL elapses', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('key', 'value');
+      fakeNow = fakeNow.add(const Duration(seconds: 11));
+
+      expect(cache.get('key'), isNull);
+      expect(cache.getKeys(), isNot(contains('key')));
+    });
+
+    test('per-entry TTL can be shorter than global TTL', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 20),
+        clock: fakeClock,
+      );
+
+      cache.set('long', 'value-long');
+      cache.set('short', 'value-short', ttl: const Duration(seconds: 5));
+
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+
+      expect(cache.get('short'), isNull);
+      expect(cache.get('long'), equals('value-long'));
+    });
+
+    test('per-entry TTL can be longer than global TTL', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 5),
+        clock: fakeClock,
+      );
+
+      cache.set('long', 'value-long', ttl: const Duration(seconds: 20));
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+
+      expect(cache.get('long'), equals('value-long'));
+    });
+  });
+
+  group('SimpleTTLCache - containsKey()', () {
+    test('distinguishes stored null from missing key until expiry', () {
+      final cache = SimpleTTLCache<String, String?>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('key', null);
+
+      expect(cache.get('key'), isNull);
+      expect(cache.containsKey('key'), isTrue);
+
+      fakeNow = fakeNow.add(const Duration(seconds: 11));
+
+      expect(cache.containsKey('key'), isFalse);
+      expect(cache.getKeys(), isNot(contains('key')));
+    });
+  });
+
+  group('SimpleTTLCache - getKeys()', () {
+    test('getKeys() excludes expired keys', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+      cache.set('b', '2');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 5));
+      cache.set('c', '3');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 6));
+
+      expect(cache.getKeys(), contains('c'));
+      expect(cache.getKeys(), isNot(contains('a')));
+      expect(cache.getKeys(), isNot(contains('b')));
+    });
+  });
+
+  group('SimpleTTLCache - maxSize FIFO eviction', () {
+    test('maxSize evicts oldest FIFO entry when capacity is exceeded', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 60),
+        maxSize: 2,
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+      cache.set('b', '2');
+      cache.set('c', '3');
+
+      expect(cache.get('a'), isNull);
+      expect(cache.get('b'), equals('2'));
+      expect(cache.get('c'), equals('3'));
+    });
+
+    test('expired entries do not count toward maxSize', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 5),
+        maxSize: 2,
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+      cache.set('b', '2');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+
+      cache.set('c', '3');
+      cache.set('d', '4');
+
+      expect(cache.get('c'), equals('3'));
+      expect(cache.get('d'), equals('4'));
+    });
+
+    test('updating an existing key refreshes FIFO order', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 60),
+        maxSize: 2,
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+      cache.set('b', '2');
+      cache.set('a', 'updated');
+      cache.set('c', '3');
+
+      expect(cache.get('a'), equals('updated'));
+      expect(cache.get('b'), isNull);
+      expect(cache.get('c'), equals('3'));
+    });
+  });
+
+  group('SimpleTTLCache - remove(), clear(), and toString()', () {
+    test('remove() deletes a specific entry', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+      cache.set('b', '2');
+      cache.remove('a');
+
+      expect(cache.get('a'), isNull);
+      expect(cache.get('b'), equals('2'));
+    });
+
+    test('clear() removes all entries', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+      cache.set('b', '2');
+      cache.clear();
+
+      expect(cache.getKeys(), isEmpty);
+      expect(cache.get('a'), isNull);
+      expect(cache.get('b'), isNull);
+    });
+
+    test('toString() excludes expired entries', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      cache.set('a', '1');
+      fakeNow = fakeNow.add(const Duration(seconds: 11));
+
+      expect(cache.toString(), isNot(contains('a: 1')));
+    });
+  });
+}


### PR DESCRIPTION
## PR Summary

Adds `SimpleTTLCache`, a synchronous TTL cache variant for single-threaded usage, and updates the public examples and documentation so TTL usage is covered across simple, async-safe, and monitored cache workflows.

### Bugfix | Feature | Documentation Update | Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [ ] Release

### Fix / Feature Details

- **SimpleTTLCache:** Adds a synchronous TTL cache with global TTL, per-entry `ttl:` overrides, lazy expiry, `containsKey()`, nullable value support, optional `maxSize`, and FIFO capacity eviction.
- **Public export:** Exports `SimpleTTLCache` from `package:cacherine/cacherine.dart`.
- **Regression coverage:** Adds tests for constructor validation, expiry behavior, per-entry TTL overrides, stored `null` values, `containsKey()`, `getKeys()`, FIFO capacity eviction, updates, `remove()`, `clear()`, and `toString()`.
- **Examples:** Replaces the empty example file with runnable examples for `SimpleTTLCache`, `TTLCache`, and monitored cache dashboard snapshots.
- **Documentation:** Updates README, TTL cache guide, and CHANGELOG with synchronous TTL usage and API references.

### Related Issue

N/A

---

## Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests

```sh
/Users/yotahara/fvm/versions/stable/bin/dart format lib/src/caches/simple_ttl_cache.dart test/caches/simple_ttl_cache_test.dart example/cacherine_example.dart lib/cacherine.dart
/Users/yotahara/fvm/versions/stable/bin/dart run example/cacherine_example.dart
/Users/yotahara/fvm/versions/stable/bin/dart test test/caches/simple_ttl_cache_test.dart
/Users/yotahara/fvm/versions/stable/bin/dart analyze
/Users/yotahara/fvm/versions/stable/bin/dart test
```

---

## Documentation Update

### Documentation Changes

- [x] Updated README
- [x] Updated API reference
- [x] Updated TTL cache guide
- [x] Updated CHANGELOG
- [x] Updated runnable example

### Additional Notes

- No dependency changes were required.
- `PR_SUMMARY.md` is intentionally not included in git.
