### PR TITLE
Add TTL-specific cache interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,17 @@
 ### New Features
 
 - **SimpleTTLCache**: Added a synchronous TTL cache variant with global and per-entry TTL, lazy expiry, `containsKey()`, optional `maxSize`, and FIFO capacity eviction.
+- **TTL cache interfaces**: Added `SimpleTTLCacheInterface` and `ThreadSafeTTLCacheInterface` so abstract cache references can still expose per-entry TTL overrides.
 
 ### Documentation
 
 - Added runnable package examples covering `SimpleTTLCache`, `TTLCache`, and monitored cache dashboard snapshots.
 - Documented synchronous TTL usage in the README and TTL guide.
+- Documented TTL-specific interfaces for callers that need per-entry expiry through cache abstractions.
+
+### Maintenance
+
+- Added regression coverage for `SimpleTTLCache`, `TTLCache`, and `MonitoredTTLCache` through the new TTL-specific interfaces.
 
 ## 2.1.0 - Monitored TTL Cache, containsKey API, and Monitoring Improvements
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,15 @@ The standard and monitored cache variants use `Future` APIs and an internal lock
 
 `get()` returns `null` when a key is absent. Use `containsKey()` to distinguish a missing key from a stored `null` value, such as `Cache<String, String?>`. `containsKey()` does not update LRU/MRU/LFU access state, does not remove entries from EphemeralFIFO caches, and does not record monitored cache hit/miss metrics. For TTL caches, expired entries return `false`.
 
+Use `SimpleTTLCacheInterface` or `ThreadSafeTTLCacheInterface` when code needs an abstraction that still exposes per-entry TTL overrides:
+
+```dart
+final ThreadSafeTTLCacheInterface<String, String> cache =
+    TTLCache(ttl: const Duration(minutes: 5));
+
+await cache.set('token', 'abc123', ttl: const Duration(seconds: 30));
+```
+
 `toString()` is synchronous. It returns a point-in-time representation of the cache contents and should be treated as diagnostic output, not as a synchronized cache operation.
 
 ## API Reference

--- a/doc/ttl_cache.md
+++ b/doc/ttl_cache.md
@@ -25,6 +25,8 @@ Lazy eviction is the correctness guarantee — the cache is always accurate. The
 
 `SimpleTTLCache` provides the same expiry, per-entry TTL, `containsKey()`, and optional `maxSize` behavior for synchronous single-threaded usage. It does not start a background sweep timer and does not implement `Disposable`; expired entries are removed lazily or ignored by read APIs.
 
+Use `SimpleTTLCacheInterface` or `ThreadSafeTTLCacheInterface` when you need a cache abstraction that preserves access to the per-entry `ttl:` override.
+
 ### 2.3 Global TTL vs Per-Entry TTL Override
 
 ```

--- a/lib/cacherine.dart
+++ b/lib/cacherine.dart
@@ -3,7 +3,9 @@ library;
 // Interfaces
 export 'src/interfaces/disposable.dart';
 export 'src/interfaces/simple_cache.dart';
+export 'src/interfaces/simple_ttl_cache.dart';
 export 'src/interfaces/thread_safe_cache.dart';
+export 'src/interfaces/thread_safe_ttl_cache.dart';
 
 // Monitorings
 export 'src/monitorings/cache_alert_manager.dart';

--- a/lib/src/caches/monitored_ttl_cache.dart
+++ b/lib/src/caches/monitored_ttl_cache.dart
@@ -4,7 +4,7 @@ import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
 import '../interfaces/disposable.dart';
-import '../interfaces/thread_safe_cache.dart';
+import '../interfaces/thread_safe_ttl_cache.dart';
 import '../monitorings/cache_alert_manager.dart';
 import '../monitorings/cache_monitoring.dart';
 
@@ -24,7 +24,7 @@ class _TTLEntry<V> {
 /// This cache records hit/miss latency through [CacheMonitoring] and records
 /// eviction events when entries are removed due to expiry, capacity limits, or
 /// explicit [remove] calls.
-class MonitoredTTLCache<K, V> extends ThreadSafeCache<K, V>
+class MonitoredTTLCache<K, V> extends ThreadSafeTTLCacheInterface<K, V>
     with CacheMonitoring<K, V>
     implements Disposable {
   final Duration _globalTTL;

--- a/lib/src/caches/simple_ttl_cache.dart
+++ b/lib/src/caches/simple_ttl_cache.dart
@@ -1,6 +1,6 @@
 import 'dart:collection';
 
-import '../interfaces/simple_cache.dart';
+import '../interfaces/simple_ttl_cache.dart';
 
 class _SimpleTTLEntry<V> {
   final V value;
@@ -18,7 +18,7 @@ class _SimpleTTLEntry<V> {
 /// or scenarios where **concurrent access is not required**.
 /// Since it is not thread-safe and does not perform synchronization,
 /// **use `TTLCache` if async-safe access is needed.**
-class SimpleTTLCache<K, V> extends SimpleCache<K, V> {
+class SimpleTTLCache<K, V> extends SimpleTTLCacheInterface<K, V> {
   final Duration _globalTTL;
   final int? _maxSize;
   final DateTime Function() _clock;

--- a/lib/src/caches/ttl_cache.dart
+++ b/lib/src/caches/ttl_cache.dart
@@ -4,7 +4,7 @@ import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
 import '../interfaces/disposable.dart';
-import '../interfaces/thread_safe_cache.dart';
+import '../interfaces/thread_safe_ttl_cache.dart';
 
 class _TTLEntry<V> {
   final V value;
@@ -19,7 +19,8 @@ class _TTLEntry<V> {
 /// expired entries proactively to reclaim memory.
 ///
 /// Implements [Disposable] — call [dispose] to cancel the sweep timer.
-class TTLCache<K, V> extends ThreadSafeCache<K, V> implements Disposable {
+class TTLCache<K, V> extends ThreadSafeTTLCacheInterface<K, V>
+    implements Disposable {
   final Duration _globalTTL;
   final int? _maxSize;
   final DateTime Function() _clock;

--- a/lib/src/interfaces/simple_ttl_cache.dart
+++ b/lib/src/interfaces/simple_ttl_cache.dart
@@ -1,0 +1,16 @@
+import 'simple_cache.dart';
+
+/// **Simple TTL Cache Interface**
+///
+/// Extends [SimpleCache] with per-entry TTL support.
+///
+/// Use this interface when code needs a synchronous cache abstraction that can
+/// override expiry duration for individual entries.
+abstract class SimpleTTLCacheInterface<K, V> extends SimpleCache<K, V> {
+  /// **Stores the specified key-value pair with an optional per-entry TTL.**
+  ///
+  /// - If [ttl] is omitted, the cache implementation's default TTL is used.
+  /// - If the key already exists, its value and expiry are updated.
+  @override
+  void set(K key, V value, {Duration? ttl});
+}

--- a/lib/src/interfaces/thread_safe_ttl_cache.dart
+++ b/lib/src/interfaces/thread_safe_ttl_cache.dart
@@ -1,0 +1,16 @@
+import 'thread_safe_cache.dart';
+
+/// **Async-safe TTL Cache Interface**
+///
+/// Extends [ThreadSafeCache] with per-entry TTL support.
+///
+/// Use this interface when code needs an async-safe cache abstraction that can
+/// override expiry duration for individual entries.
+abstract class ThreadSafeTTLCacheInterface<K, V> extends ThreadSafeCache<K, V> {
+  /// **Stores the specified key-value pair with an optional per-entry TTL.**
+  ///
+  /// - If [ttl] is omitted, the cache implementation's default TTL is used.
+  /// - If the key already exists, its value and expiry are updated.
+  @override
+  Future<void> set(K key, V value, {Duration? ttl});
+}

--- a/test/interfaces/ttl_cache_interfaces_test.dart
+++ b/test/interfaces/ttl_cache_interfaces_test.dart
@@ -1,0 +1,133 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  DateTime fakeNow = DateTime(2024);
+  DateTime fakeClock() => fakeNow;
+
+  setUp(() {
+    fakeNow = DateTime(2024);
+  });
+
+  group('SimpleTTLCacheInterface', () {
+    test('SimpleTTLCache implements the public TTL interface', () {
+      final cache = SimpleTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      expect(cache, isA<SimpleCache<String, String>>());
+      expect(cache, isA<SimpleTTLCacheInterface<String, String>>());
+    });
+
+    test('allows per-entry TTL overrides through the interface', () {
+      final SimpleTTLCacheInterface<String, String> cache =
+          SimpleTTLCache<String, String>(
+            ttl: const Duration(seconds: 30),
+            clock: fakeClock,
+          );
+
+      cache.set('default', 'live');
+      cache.set('short', 'expired', ttl: const Duration(seconds: 5));
+
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+
+      expect(cache.get('default'), equals('live'));
+      expect(cache.get('short'), isNull);
+      expect(cache.containsKey('default'), isTrue);
+      expect(cache.containsKey('short'), isFalse);
+    });
+
+    test('validates per-entry TTL overrides through the interface', () {
+      final SimpleTTLCacheInterface<String, String> cache =
+          SimpleTTLCache<String, String>(
+            ttl: const Duration(seconds: 30),
+            clock: fakeClock,
+          );
+
+      expect(
+        () => cache.set('key', 'value', ttl: Duration.zero),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('ThreadSafeTTLCacheInterface', () {
+    test('TTLCache implements the public TTL interface', () {
+      final cache = TTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+      );
+
+      expect(cache, isA<ThreadSafeCache<String, String>>());
+      expect(cache, isA<ThreadSafeTTLCacheInterface<String, String>>());
+    });
+
+    test('MonitoredTTLCache implements the public TTL interface', () {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 10),
+        clock: fakeClock,
+        alertConfig: CacheAlertConfig(notifyCallback: (_) {}),
+      );
+      addTearDown(cache.dispose);
+
+      expect(cache, isA<ThreadSafeCache<String, String>>());
+      expect(cache, isA<ThreadSafeTTLCacheInterface<String, String>>());
+    });
+
+    test('allows per-entry TTL overrides through TTLCache interface', () async {
+      final ThreadSafeTTLCacheInterface<String, String> cache =
+          TTLCache<String, String>(
+            ttl: const Duration(seconds: 30),
+            clock: fakeClock,
+          );
+
+      await cache.set('default', 'live');
+      await cache.set('short', 'expired', ttl: const Duration(seconds: 5));
+
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+
+      expect(await cache.get('default'), equals('live'));
+      expect(await cache.get('short'), isNull);
+      expect(await cache.containsKey('default'), isTrue);
+      expect(await cache.containsKey('short'), isFalse);
+    });
+
+    test(
+      'allows per-entry TTL overrides through MonitoredTTLCache interface',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 30),
+          clock: fakeClock,
+          alertConfig: CacheAlertConfig(notifyCallback: (_) {}),
+        );
+        addTearDown(cache.dispose);
+
+        final ThreadSafeTTLCacheInterface<String, String> ttlCache = cache;
+
+        await ttlCache.set('default', 'live');
+        await ttlCache.set('short', 'expired', ttl: const Duration(seconds: 5));
+
+        fakeNow = fakeNow.add(const Duration(seconds: 10));
+
+        expect(await ttlCache.get('default'), equals('live'));
+        expect(await ttlCache.get('short'), isNull);
+        expect(cache.metrics.hits, equals(1));
+        expect(cache.metrics.misses, equals(1));
+      },
+    );
+
+    test('validates per-entry TTL overrides through the interface', () async {
+      final ThreadSafeTTLCacheInterface<String, String> cache =
+          TTLCache<String, String>(
+            ttl: const Duration(seconds: 30),
+            clock: fakeClock,
+          );
+
+      await expectLater(
+        () => cache.set('key', 'value', ttl: Duration.zero),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## PR Summary

Adds public TTL-specific cache interfaces so callers can keep using per-entry `ttl:` overrides when working through cache abstractions instead of concrete TTL cache classes.

### Bugfix | Feature | Documentation Update | Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [ ] Release

### Fix / Feature Details

- **TTL interfaces:** Adds `SimpleTTLCacheInterface` and `ThreadSafeTTLCacheInterface` with `set(K key, V value, {Duration? ttl})`.
- **Public export:** Exports the new interfaces from `package:cacherine/cacherine.dart`.
- **Implementation wiring:** Updates `SimpleTTLCache`, `TTLCache`, and `MonitoredTTLCache` to implement the TTL-specific interfaces.
- **Regression coverage:** Adds interface-level tests that verify type compatibility, per-entry TTL overrides, expiry behavior, validation, and monitored hit/miss metrics through the new abstractions.
- **Documentation:** Updates README, TTL cache guide, and CHANGELOG with TTL interface usage and release notes.

### Related Issue

N/A

---

## Testing

- [x] Unit tests passed
- [x] Coverage flow passed
- [x] Added regression tests

```sh
/Users/yotahara/fvm/versions/stable/bin/dart format .
/Users/yotahara/fvm/versions/stable/bin/dart analyze --fatal-infos
/Users/yotahara/fvm/versions/stable/bin/dart test test/interfaces/ttl_cache_interfaces_test.dart
/Users/yotahara/fvm/versions/stable/bin/dart test
/Users/yotahara/fvm/versions/stable/bin/dart test --coverage=coverage/
/Users/yotahara/fvm/versions/stable/bin/dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
```

---

## Documentation Update

### Documentation Changes

- [x] Updated README
- [x] Updated API exports
- [x] Updated TTL cache guide
- [x] Updated CHANGELOG

### Additional Notes

- No dependency changes were required.
- New interface files contain abstract declarations only; LCOV does not report them as uncovered executable lines.
- `PR_SUMMARY.md` is intentionally not included in git.
