### PR TITLE
Add cache compute helpers and lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@
 
 - **SimpleTTLCache**: Added a synchronous TTL cache variant with global and per-entry TTL, lazy expiry, `containsKey()`, optional `maxSize`, and FIFO capacity eviction.
 - **TTL cache interfaces**: Added `SimpleTTLCacheInterface` and `ThreadSafeTTLCacheInterface` so abstract cache references can still expose per-entry TTL overrides.
+- **Cache-aside population**: Added `getOrSet()` to simple caches and `getOrCompute()` to async-safe caches, including TTL per-entry override support through TTL-specific interfaces.
 
 ### Documentation
 
 - Added runnable package examples covering `SimpleTTLCache`, `TTLCache`, and monitored cache dashboard snapshots.
 - Documented synchronous TTL usage in the README and TTL guide.
 - Documented TTL-specific interfaces for callers that need per-entry expiry through cache abstractions.
+- Documented `getKeys()` ordering contracts, `Disposable` lifecycle behavior, and bounded `CacheMetrics` sample storage.
 
 ### Maintenance
 
 - Added regression coverage for `SimpleTTLCache`, `TTLCache`, and `MonitoredTTLCache` through the new TTL-specific interfaces.
+- Added regression coverage for cache-aside population, `dispose()` idempotency, post-dispose operations, and `getKeys()` ordering contracts.
 
 ## 2.1.0 - Monitored TTL Cache, containsKey API, and Monitoring Improvements
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ void main() async {
 }
 ```
 
+Use `getOrSet()` on synchronous caches or `getOrCompute()` on async caches when
+you want to populate a missing key from a callback:
+
+```dart
+final cache = LRUCache<String, String>(100);
+
+final value = await cache.getOrCompute('profile:42', () async {
+  return 'computed value';
+});
+```
+
 ### TTL Usage
 
 Entries expire automatically once their TTL elapses. Use `ttl:` on individual `set()` calls to override the global default for a single entry.
@@ -177,6 +188,10 @@ The standard and monitored cache variants use `Future` APIs and an internal lock
 
 `get()` returns `null` when a key is absent. Use `containsKey()` to distinguish a missing key from a stored `null` value, such as `Cache<String, String?>`. `containsKey()` does not update LRU/MRU/LFU access state, does not remove entries from EphemeralFIFO caches, and does not record monitored cache hit/miss metrics. For TTL caches, expired entries return `false`.
 
+`getOrSet()` and `getOrCompute()` use `containsKey()` semantics before reading, so stored `null` values are treated as present. On monitored caches, `getOrCompute()` records one hit when the key already exists and one miss when the callback is used to populate the key.
+
+`getKeys()` returns a snapshot. FIFO and TTL caches return insertion order for live entries. LRU and MRU caches return least-to-most recently used order. Ephemeral FIFO caches omit entries already consumed by `get()`. LFU cache key order is unspecified.
+
 Use `SimpleTTLCacheInterface` or `ThreadSafeTTLCacheInterface` when code needs an abstraction that still exposes per-entry TTL overrides:
 
 ```dart
@@ -187,6 +202,16 @@ await cache.set('token', 'abc123', ttl: const Duration(seconds: 30));
 ```
 
 `toString()` is synchronous. It returns a point-in-time representation of the cache contents and should be treated as diagnostic output, not as a synchronized cache operation.
+
+Caches that implement `Disposable` own a background timer for sweeping expired
+entries, checking alert thresholds, or both. Call `dispose()` when the cache is
+no longer needed. It is idempotent; after disposal, cache read/write operations
+continue to work, but background sweep and alert monitoring stop.
+
+`CacheMetrics` keeps bounded in-memory samples: the most recent 1,000 latency
+samples and 10,000 eviction timestamps. Hit, miss, and total request counters are
+not capped. Latency percentiles and eviction rates are calculated from the
+retained samples.
 
 ## API Reference
 

--- a/doc/ephemeral_fifo_cache.md
+++ b/doc/ephemeral_fifo_cache.md
@@ -47,7 +47,12 @@ The eviction policy of the Ephemeral FIFO Cache follows these rules:
    - If the cache exceeds the `[maxSize]`, the oldest data is removed based on the FIFO policy.
    - Add the new key-value pair to the cache.
 
-### 3.3 Example: Ephemeral FIFO Cache Operations and State Changes
+### 3.3 Key Snapshot (`getKeys` operation)
+
+`getKeys()` returns the remaining keys in FIFO insertion order. Keys already
+retrieved by `get()` are removed from the cache and are not included.
+
+### 3.4 Example: Ephemeral FIFO Cache Operations and State Changes
 
 1. Initial State: EphemeralFIFOCache<maxCount: 3>
 

--- a/doc/fifo_cache.md
+++ b/doc/fifo_cache.md
@@ -40,7 +40,12 @@ The FIFO Cache eviction policy follows these rules:
    - If the cache exceeds the [maxSize], evict the first inserted entry based on FIFO policy.
    - Add the new key-value pair.
 
-### 3.3 Example: FIFO Cache Operations and State Changes
+### 3.3 Key Snapshot (`getKeys` operation)
+
+`getKeys()` returns keys in FIFO insertion order. Updating an existing key
+changes its value but keeps its current position.
+
+### 3.4 Example: FIFO Cache Operations and State Changes
 
 1. Initial State: FIFOCache<maxCount: 3>
 

--- a/doc/lfu_cache.md
+++ b/doc/lfu_cache.md
@@ -43,7 +43,12 @@ The LFU Cache eviction policy follows these rules:
    - If the cache exceeds the [maxSize], evict entries based on LFU policy.
    - Add the new key-value pair and initialize the frequency counter to 1.
 
-### 3.3 Example: LFUCache operations and state changes
+### 3.3 Key Snapshot (`getKeys` operation)
+
+`getKeys()` returns a snapshot of current keys, but the order is unspecified.
+Do not use it to infer frequency, recency, or eviction order.
+
+### 3.4 Example: LFUCache operations and state changes
 
 1. Initial state: LFUCache<maxCount: 3>
 

--- a/doc/lru_cache.md
+++ b/doc/lru_cache.md
@@ -40,7 +40,12 @@ The eviction policy of an LRU Cache follows these rules:
    - If the cache exceeds the [maxSize], evict the least recently accessed entry based on the LRU policy.
    - Add the new key-value pair.
 
-### 3.3 Example: LRUCache Operations and State Changes
+### 3.3 Key Snapshot (`getKeys` operation)
+
+`getKeys()` returns keys from least recently used to most recently used. A
+successful `get()` or `set()` of an existing key moves that key to the end.
+
+### 3.4 Example: LRUCache Operations and State Changes
 
 1. Initial State: LRUCache<maxCount: 3>
 

--- a/doc/monitored_cache.md
+++ b/doc/monitored_cache.md
@@ -109,6 +109,12 @@ metrics for custom dashboards or alert integrations. It returns a
 `CacheMetricsSnapshot` with hit/miss rates, average latency, p50/p95/p99
 latency, eviction rate, total requests, and capture time.
 
+`CacheMetrics` uses bounded sample storage: it keeps the most recent 1,000
+latency samples and 10,000 eviction timestamps. Hit, miss, and total request
+counters are not capped. Average latency and percentiles are calculated from the
+retained latency samples; eviction rates are calculated from retained eviction
+timestamps inside the requested window.
+
 ```dart
 import 'package:cacherine/cacherine.dart';
 
@@ -125,6 +131,15 @@ Future<void> main() async {
   cache.dispose();
 }
 ```
+
+## Lifecycle
+
+Monitored caches implement `Disposable` because they own an alert-monitoring
+timer. `MonitoredTTLCache` may also own a TTL sweep timer. Call `dispose()` when
+the cache is no longer needed to stop those background timers.
+
+`dispose()` is idempotent. Cache operations continue to work after disposal, but
+alert checks and background TTL sweeps stop.
 
 ## Why Use MonitoredCache?
 

--- a/doc/mru_cache.md
+++ b/doc/mru_cache.md
@@ -40,7 +40,13 @@ The eviction policy of MRU Cache follows these rules:
    - If the cache exceeds the [maxSize], evict the most recently accessed entry based on the MRU policy.
    - Add the new key-value pair.
 
-### 3.3 Example: MRUCache Operations and State Changes
+### 3.3 Key Snapshot (`getKeys` operation)
+
+`getKeys()` returns keys from least recently used to most recently used. The
+last key in the snapshot is the next eviction candidate if a new key is inserted
+while the cache is full.
+
+### 3.4 Example: MRUCache Operations and State Changes
 
 1. Initial State: MRUCache<maxCount: 3>
 

--- a/doc/ttl_cache.md
+++ b/doc/ttl_cache.md
@@ -64,7 +64,19 @@ Use `containsKey()` to distinguish a missing key from a stored `null` value.
    b. If still at or over capacity, remove the oldest-inserted live entry (FIFO).
 3. Store the entry with expiry = `clock() + ttl`.
 
-### 3.4 Example: TTLCache Operations and State Changes
+### 3.4 Cache-Aside Population (`getOrSet` / `getOrCompute`)
+
+Use `getOrSet()` on `SimpleTTLCache` or `getOrCompute()` on `TTLCache` and
+`MonitoredTTLCache` to return an existing live value or populate a missing or
+expired key from a callback. The optional `ttl:` argument applies only when the
+callback value is stored.
+
+### 3.5 Key Snapshot (`getKeys` operation)
+
+`getKeys()` returns only live keys in insertion order. Expired entries are
+omitted even if they have not yet been swept from memory.
+
+### 3.6 Example: TTLCache Operations and State Changes
 
 Setup: `TTLCache(ttl: Duration(seconds: 10), maxSize: 3)`  
 (clock starts at t=0)
@@ -125,7 +137,9 @@ final cache = TTLCache<String, String>(
 cache.dispose(); // cancel sweep timer
 ```
 
-`dispose()` is idempotent — calling it multiple times is safe. After `dispose()`, `get()` and `set()` continue to work; only the background sweep stops.
+`dispose()` is idempotent — calling it multiple times is safe. After
+`dispose()`, `get()`, `set()`, `getOrCompute()`, `remove()`, and `clear()`
+continue to work; only the background sweep stops.
 
 ## 6. Monitoring
 
@@ -158,6 +172,7 @@ cache.dispose();
 | Method | Description |
 |--------|-------------|
 | `set(K key, V value, {Duration? ttl})` | Store an entry. `ttl:` overrides the global TTL for this entry. |
+| `getOrCompute(K key, callback, {Duration? ttl})` | Return an existing live value, or compute and store a new value. `ttl:` applies to newly stored values only. |
 | `get(K key)` | Retrieve a value, or `null` if missing or expired (lazy eviction). |
 | `containsKey(K key)` | Return whether a non-expired entry exists for the key. Expired entries are removed and return `false`. |
 | `getKeys()` | Return only keys whose TTL has not elapsed. |

--- a/lib/src/caches/ephemeral_fifo_cache.dart
+++ b/lib/src/caches/ephemeral_fifo_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
@@ -81,6 +82,19 @@ class EphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V> {
         ); // Remove the oldest element following FIFO
       }
       _cache[key] = value; // Update value (order remains unchanged)
+    });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    return await _lock.synchronized(() async {
+      if (_cache.containsKey(key)) return _cache.remove(key) as V;
+      final value = await valueFactory();
+      if (_cache.length >= maxSize) {
+        _cache.remove(_cache.keys.first);
+      }
+      _cache[key] = value;
+      return value;
     });
   }
 

--- a/lib/src/caches/fifo_cache.dart
+++ b/lib/src/caches/fifo_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
@@ -74,6 +75,19 @@ class FIFOCache<K, V> extends ThreadSafeCache<K, V> {
         ); // Remove the oldest element following FIFO
       }
       _cache[key] = value; // Update value (order remains unchanged)
+    });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    return await _lock.synchronized(() async {
+      if (_cache.containsKey(key)) return _cache[key] as V;
+      final value = await valueFactory();
+      if (_cache.length >= maxSize) {
+        _cache.remove(_cache.keys.first);
+      }
+      _cache[key] = value;
+      return value;
     });
   }
 

--- a/lib/src/caches/lfu_cache.dart
+++ b/lib/src/caches/lfu_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
@@ -137,6 +138,30 @@ class LFUCache<K, V> extends ThreadSafeCache<K, V> {
       _keyMap[key] = node;
       _freqMap.putIfAbsent(1, LinkedList<_LFUNode<K, V>>.new).addFirst(node);
       _minFreq = 1;
+    });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    return await _lock.synchronized(() async {
+      final existing = _keyMap[key];
+      if (existing != null) {
+        _promoteFreq(existing);
+        return existing.value;
+      }
+      final value = await valueFactory();
+      if (_keyMap.length >= maxSize) {
+        final evictBucket = _freqMap[_minFreq]!;
+        final victim = evictBucket.last;
+        victim.unlink();
+        if (evictBucket.isEmpty) _freqMap.remove(_minFreq);
+        _keyMap.remove(victim.key);
+      }
+      final node = _LFUNode(key, value, 1);
+      _keyMap[key] = node;
+      _freqMap.putIfAbsent(1, LinkedList<_LFUNode<K, V>>.new).addFirst(node);
+      _minFreq = 1;
+      return value;
     });
   }
 

--- a/lib/src/caches/lru_cache.dart
+++ b/lib/src/caches/lru_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
@@ -82,6 +83,23 @@ class LRUCache<K, V> extends ThreadSafeCache<K, V> {
         ); // Remove the least recently used element
       }
       _cache[key] = value;
+    });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    return await _lock.synchronized(() async {
+      if (_cache.containsKey(key)) {
+        final value = _cache.remove(key);
+        _cache[key] = value as V;
+        return value;
+      }
+      final value = await valueFactory();
+      if (_cache.length >= maxSize) {
+        _cache.remove(_cache.keys.first);
+      }
+      _cache[key] = value;
+      return value;
     });
   }
 

--- a/lib/src/caches/monitored_ephemeral_fifo_cache.dart
+++ b/lib/src/caches/monitored_ephemeral_fifo_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:synchronized/synchronized.dart';
@@ -113,6 +114,27 @@ class MonitoredEphemeralFIFOCache<K, V> extends ThreadSafeCache<K, V>
       }
       _cache[key] = value; // Update value (position remains unchanged)
     });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    var found = false;
+    return await monitoredGet(key, () async {
+          return await _lock.synchronized(() async {
+            if (_cache.containsKey(key)) {
+              found = true;
+              return _cache.remove(key) as V;
+            }
+            final value = await valueFactory();
+            if (_cache.length >= maxSize) {
+              _cache.remove(_cache.keys.first);
+              metrics.recordEviction();
+            }
+            _cache[key] = value;
+            return value;
+          });
+        }, found: () => found)
+        as V;
   }
 
   /// Removes the entry with the given key from the cache.

--- a/lib/src/caches/monitored_fifo_cache.dart
+++ b/lib/src/caches/monitored_fifo_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:synchronized/synchronized.dart';
@@ -115,6 +116,27 @@ class MonitoredFIFOCache<K, V> extends ThreadSafeCache<K, V>
       }
       _cache[key] = value; // Update value (position remains unchanged)
     });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    var found = false;
+    return await monitoredGet(key, () async {
+          return await _lock.synchronized(() async {
+            if (_cache.containsKey(key)) {
+              found = true;
+              return _cache[key] as V;
+            }
+            final value = await valueFactory();
+            if (_cache.length >= maxSize) {
+              _cache.remove(_cache.keys.first);
+              metrics.recordEviction();
+            }
+            _cache[key] = value;
+            return value;
+          });
+        }, found: () => found)
+        as V;
   }
 
   /// Removes the entry with the given key from the cache.

--- a/lib/src/caches/monitored_lfu_cache.dart
+++ b/lib/src/caches/monitored_lfu_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
@@ -153,6 +154,34 @@ class MonitoredLFUCache<K, V> extends ThreadSafeCache<K, V>
       _freqMap.putIfAbsent(1, LinkedList<_LFUNode<K, V>>.new).addFirst(node);
       _minFreq = 1;
     });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    var found = false;
+    return await monitoredGet(key, () async {
+          return await _lock.synchronized(() async {
+            final existing = _keyMap[key];
+            if (existing != null) {
+              found = true;
+              _promoteFreq(existing);
+              return existing.value;
+            }
+            final value = await valueFactory();
+            if (_keyMap.length >= maxSize) {
+              _evictLFUEntry();
+              metrics.recordEviction();
+            }
+            final node = _LFUNode(key, value, 1);
+            _keyMap[key] = node;
+            _freqMap
+                .putIfAbsent(1, LinkedList<_LFUNode<K, V>>.new)
+                .addFirst(node);
+            _minFreq = 1;
+            return value;
+          });
+        }, found: () => found)
+        as V;
   }
 
   /// Performs eviction using the LFU (Least Frequently Used) policy.

--- a/lib/src/caches/monitored_lru_cache.dart
+++ b/lib/src/caches/monitored_lru_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:synchronized/synchronized.dart';
@@ -122,6 +123,29 @@ class MonitoredLRUCache<K, V> extends ThreadSafeCache<K, V>
       }
       _cache[key] = value;
     });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    var found = false;
+    return await monitoredGet(key, () async {
+          return await _lock.synchronized(() async {
+            if (_cache.containsKey(key)) {
+              found = true;
+              final value = _cache.remove(key);
+              _cache[key] = value as V;
+              return value;
+            }
+            final value = await valueFactory();
+            if (_cache.length >= maxSize) {
+              _cache.remove(_cache.keys.first);
+              metrics.recordEviction();
+            }
+            _cache[key] = value;
+            return value;
+          });
+        }, found: () => found)
+        as V;
   }
 
   /// Removes the entry with the given key from the cache.

--- a/lib/src/caches/monitored_mru_cache.dart
+++ b/lib/src/caches/monitored_mru_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
@@ -120,6 +121,29 @@ class MonitoredMRUCache<K, V> extends ThreadSafeCache<K, V>
       // Insert the key to mark it as the most recently used
       _cache[key] = value;
     });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    var found = false;
+    return await monitoredGet(key, () async {
+          return await _lock.synchronized(() async {
+            if (_cache.containsKey(key)) {
+              found = true;
+              final value = _cache.remove(key);
+              _cache[key] = value as V;
+              return value;
+            }
+            final value = await valueFactory();
+            if (_cache.length >= maxSize) {
+              _evictMRUEntry();
+              metrics.recordEviction();
+            }
+            _cache[key] = value;
+            return value;
+          });
+        }, found: () => found)
+        as V;
   }
 
   /// Performs eviction (removal) using the MRU (Most Recently Used) policy.

--- a/lib/src/caches/monitored_ttl_cache.dart
+++ b/lib/src/caches/monitored_ttl_cache.dart
@@ -177,6 +177,37 @@ class MonitoredTTLCache<K, V> extends ThreadSafeTTLCacheInterface<K, V>
   }
 
   @override
+  Future<V> getOrCompute(
+    K key,
+    FutureOr<V> Function() valueFactory, {
+    Duration? ttl,
+  }) async {
+    if (ttl != null && ttl <= Duration.zero) {
+      throw ArgumentError('ttl must be greater than zero.');
+    }
+    var found = false;
+    return await monitoredGet(key, () async {
+          return await _lock.synchronized(() async {
+            final entry = _cache[key];
+            final now = _clock();
+            if (entry != null) {
+              if (entry.expiry.isAfter(now)) {
+                found = true;
+                return entry.value;
+              }
+              _cache.remove(key);
+              metrics.recordEviction();
+            }
+            final value = await valueFactory();
+            _evictIfNeeded();
+            _cache[key] = _TTLEntry(value, _clock().add(ttl ?? _globalTTL));
+            return value;
+          });
+        }, found: () => found)
+        as V;
+  }
+
+  @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
       if (_cache.remove(key) != null) {

--- a/lib/src/caches/mru_cache.dart
+++ b/lib/src/caches/mru_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'package:synchronized/synchronized.dart';
 
@@ -81,6 +82,23 @@ class MRUCache<K, V> extends ThreadSafeCache<K, V> {
       }
       // Insert the key to mark it as the most recently used
       _cache[key] = value;
+    });
+  }
+
+  @override
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    return await _lock.synchronized(() async {
+      if (_cache.containsKey(key)) {
+        final value = _cache.remove(key);
+        _cache[key] = value as V;
+        return value;
+      }
+      final value = await valueFactory();
+      if (_cache.length >= maxSize) {
+        _evictMRUEntry();
+      }
+      _cache[key] = value;
+      return value;
     });
   }
 

--- a/lib/src/caches/ttl_cache.dart
+++ b/lib/src/caches/ttl_cache.dart
@@ -138,6 +138,29 @@ class TTLCache<K, V> extends ThreadSafeTTLCacheInterface<K, V>
   }
 
   @override
+  Future<V> getOrCompute(
+    K key,
+    FutureOr<V> Function() valueFactory, {
+    Duration? ttl,
+  }) async {
+    if (ttl != null && ttl <= Duration.zero) {
+      throw ArgumentError('ttl must be greater than zero.');
+    }
+    return await _lock.synchronized(() async {
+      final entry = _cache[key];
+      final now = _clock();
+      if (entry != null) {
+        if (entry.expiry.isAfter(now)) return entry.value;
+        _cache.remove(key);
+      }
+      final value = await valueFactory();
+      _evictIfNeeded();
+      _cache[key] = _TTLEntry(value, _clock().add(ttl ?? _globalTTL));
+      return value;
+    });
+  }
+
+  @override
   Future<void> remove(K key) async {
     await _lock.synchronized(() {
       _cache.remove(key);

--- a/lib/src/interfaces/simple_cache.dart
+++ b/lib/src/interfaces/simple_cache.dart
@@ -39,6 +39,22 @@ abstract class SimpleCache<K, V> {
   /// - `value`: The value of the data to store.
   void set(K key, V value);
 
+  /// **Returns the existing value for [key], or stores and returns a new one.**
+  ///
+  /// Presence is checked with [containsKey], so a stored `null` value is treated
+  /// as an existing value when `V` is nullable.
+  ///
+  /// Implementations that update access state from [get] apply the same access
+  /// behavior when the key already exists.
+  V getOrSet(K key, V Function() valueFactory) {
+    if (containsKey(key)) {
+      return get(key) as V;
+    }
+    final value = valueFactory();
+    set(key, value);
+    return value;
+  }
+
   /// **Removes the entry with the given key from the cache.**
   ///
   /// - If the key does not exist, this call is a no-op.

--- a/lib/src/interfaces/simple_ttl_cache.dart
+++ b/lib/src/interfaces/simple_ttl_cache.dart
@@ -13,4 +13,18 @@ abstract class SimpleTTLCacheInterface<K, V> extends SimpleCache<K, V> {
   /// - If the key already exists, its value and expiry are updated.
   @override
   void set(K key, V value, {Duration? ttl});
+
+  /// **Returns the existing value for [key], or stores and returns a new one.**
+  ///
+  /// When a new value is stored, [ttl] overrides the implementation's default
+  /// TTL for that entry.
+  @override
+  V getOrSet(K key, V Function() valueFactory, {Duration? ttl}) {
+    if (containsKey(key)) {
+      return get(key) as V;
+    }
+    final value = valueFactory();
+    set(key, value, ttl: ttl);
+    return value;
+  }
 }

--- a/lib/src/interfaces/thread_safe_cache.dart
+++ b/lib/src/interfaces/thread_safe_cache.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 /// **Async-safe Cache Interface**
 ///
 /// An abstract class defining basic cache operations for asynchronous use.
@@ -40,6 +42,22 @@ abstract class ThreadSafeCache<K, V> {
   /// - `key`: The key for the data to store.
   /// - `value`: The value of the data to store.
   Future<void> set(K key, V value);
+
+  /// **Returns the existing value for [key], or computes, stores, and returns a new one.**
+  ///
+  /// Presence is checked with [containsKey], so a stored `null` value is treated
+  /// as an existing value when `V` is nullable.
+  ///
+  /// Implementations may override this method to make the check/compute/store
+  /// sequence atomic for their synchronization model.
+  Future<V> getOrCompute(K key, FutureOr<V> Function() valueFactory) async {
+    if (await containsKey(key)) {
+      return await get(key) as V;
+    }
+    final value = await valueFactory();
+    await set(key, value);
+    return value;
+  }
 
   /// **Removes the entry with the given key from the cache (asynchronously).**
   ///

--- a/lib/src/interfaces/thread_safe_ttl_cache.dart
+++ b/lib/src/interfaces/thread_safe_ttl_cache.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'thread_safe_cache.dart';
 
 /// **Async-safe TTL Cache Interface**
@@ -13,4 +15,22 @@ abstract class ThreadSafeTTLCacheInterface<K, V> extends ThreadSafeCache<K, V> {
   /// - If the key already exists, its value and expiry are updated.
   @override
   Future<void> set(K key, V value, {Duration? ttl});
+
+  /// **Returns the existing value for [key], or computes, stores, and returns a new one.**
+  ///
+  /// When a new value is stored, [ttl] overrides the implementation's default
+  /// TTL for that entry.
+  @override
+  Future<V> getOrCompute(
+    K key,
+    FutureOr<V> Function() valueFactory, {
+    Duration? ttl,
+  }) async {
+    if (await containsKey(key)) {
+      return await get(key) as V;
+    }
+    final value = await valueFactory();
+    await set(key, value, ttl: ttl);
+    return value;
+  }
 }

--- a/test/caches/disposable_lifecycle_test.dart
+++ b/test/caches/disposable_lifecycle_test.dart
@@ -1,0 +1,43 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Disposable lifecycle', () {
+    final factories = <String, ThreadSafeCache<String, String> Function()>{
+      'MonitoredFIFOCache': () => MonitoredFIFOCache(maxSize: 2),
+      'MonitoredEphemeralFIFOCache': () =>
+          MonitoredEphemeralFIFOCache(maxSize: 2),
+      'MonitoredLRUCache': () => MonitoredLRUCache(maxSize: 2),
+      'MonitoredMRUCache': () => MonitoredMRUCache(maxSize: 2),
+      'MonitoredLFUCache': () => MonitoredLFUCache(maxSize: 2),
+      'TTLCache': () => TTLCache(ttl: const Duration(seconds: 30)),
+      'MonitoredTTLCache': () =>
+          MonitoredTTLCache(ttl: const Duration(seconds: 30)),
+    };
+
+    for (final entry in factories.entries) {
+      test(
+        '${entry.key} dispose is idempotent and cache operations still work',
+        () async {
+          final cache = entry.value();
+          final disposable = cache as Disposable;
+
+          expect(() {
+            disposable.dispose();
+            disposable.dispose();
+          }, returnsNormally);
+
+          await cache.set('key', 'value');
+
+          expect(await cache.get('key'), equals('value'));
+          await cache.remove('key');
+          expect(await cache.containsKey('key'), isFalse);
+
+          await cache.set('a', 'A');
+          await cache.clear();
+          expect(await cache.getKeys(), isEmpty);
+        },
+      );
+    }
+  });
+}

--- a/test/caches/get_keys_order_test.dart
+++ b/test/caches/get_keys_order_test.dart
@@ -1,0 +1,68 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getKeys() order contract', () {
+    test(
+      'FIFO caches return insertion order and updates keep position',
+      () async {
+        final cache = FIFOCache<String, String>(3);
+
+        await cache.set('a', 'A');
+        await cache.set('b', 'B');
+        await cache.set('a', 'updated');
+        await cache.set('c', 'C');
+
+        expect(await cache.getKeys(), equals(['a', 'b', 'c']));
+      },
+    );
+
+    test('Ephemeral FIFO returns remaining keys in insertion order', () async {
+      final cache = EphemeralFIFOCache<String, String>(3);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+      await cache.set('c', 'C');
+      await cache.get('b');
+
+      expect(await cache.getKeys(), equals(['a', 'c']));
+    });
+
+    test('LRU getKeys returns least to most recently used', () async {
+      final cache = LRUCache<String, String>(3);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+      await cache.set('c', 'C');
+      await cache.get('a');
+
+      expect(await cache.getKeys(), equals(['b', 'c', 'a']));
+    });
+
+    test('MRU getKeys returns least to most recently used', () async {
+      final cache = MRUCache<String, String>(3);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+      await cache.set('c', 'C');
+      await cache.get('a');
+
+      expect(await cache.getKeys(), equals(['b', 'c', 'a']));
+    });
+
+    test('TTL getKeys returns live keys in insertion order', () async {
+      var now = DateTime(2024);
+      final cache = TTLCache<String, String>(
+        ttl: const Duration(seconds: 30),
+        clock: () => now,
+      );
+
+      await cache.set('expired', 'old', ttl: const Duration(seconds: 5));
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+      now = now.add(const Duration(seconds: 10));
+
+      expect(await cache.getKeys(), equals(['a', 'b']));
+    });
+  });
+}

--- a/test/interfaces/cache_get_or_compute_test.dart
+++ b/test/interfaces/cache_get_or_compute_test.dart
@@ -1,0 +1,183 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SimpleCache.getOrSet()', () {
+    final factories = <String, SimpleCache<String, String?> Function()>{
+      'SimpleFIFOCache': () => SimpleFIFOCache<String, String?>(2),
+      'SimpleEphemeralFIFOCache': () =>
+          SimpleEphemeralFIFOCache<String, String?>(2),
+      'SimpleLRUCache': () => SimpleLRUCache<String, String?>(2),
+      'SimpleMRUCache': () => SimpleMRUCache<String, String?>(2),
+      'SimpleLFUCache': () => SimpleLFUCache<String, String?>(2),
+    };
+
+    for (final entry in factories.entries) {
+      test('${entry.key} returns existing stored null without computing', () {
+        final cache = entry.value();
+        var computes = 0;
+
+        cache.set('key', null);
+
+        expect(
+          cache.getOrSet('key', () {
+            computes++;
+            return 'computed';
+          }),
+          isNull,
+        );
+        expect(computes, equals(0));
+      });
+
+      test('${entry.key} computes missing value once and stores it', () {
+        final cache = entry.value();
+        var computes = 0;
+
+        final value = cache.getOrSet('key', () {
+          computes++;
+          return 'computed';
+        });
+
+        expect(value, equals('computed'));
+        expect(computes, equals(1));
+        expect(cache.containsKey('key'), isTrue);
+      });
+    }
+  });
+
+  group('ThreadSafeCache.getOrCompute()', () {
+    final factories = <String, ThreadSafeCache<String, String?> Function()>{
+      'FIFOCache': () => FIFOCache<String, String?>(2),
+      'EphemeralFIFOCache': () => EphemeralFIFOCache<String, String?>(2),
+      'LRUCache': () => LRUCache<String, String?>(2),
+      'MRUCache': () => MRUCache<String, String?>(2),
+      'LFUCache': () => LFUCache<String, String?>(2),
+      'MonitoredFIFOCache': () =>
+          MonitoredFIFOCache<String, String?>(maxSize: 2),
+      'MonitoredEphemeralFIFOCache': () =>
+          MonitoredEphemeralFIFOCache<String, String?>(maxSize: 2),
+      'MonitoredLRUCache': () => MonitoredLRUCache<String, String?>(maxSize: 2),
+      'MonitoredMRUCache': () => MonitoredMRUCache<String, String?>(maxSize: 2),
+      'MonitoredLFUCache': () => MonitoredLFUCache<String, String?>(maxSize: 2),
+    };
+
+    for (final entry in factories.entries) {
+      test(
+        '${entry.key} returns existing stored null without computing',
+        () async {
+          final cache = entry.value();
+          addTearDown(() {
+            if (cache case Disposable disposable) disposable.dispose();
+          });
+          var computes = 0;
+
+          await cache.set('key', null);
+
+          expect(
+            await cache.getOrCompute('key', () {
+              computes++;
+              return 'computed';
+            }),
+            isNull,
+          );
+          expect(computes, equals(0));
+        },
+      );
+
+      test(
+        '${entry.key} serializes concurrent computations per instance',
+        () async {
+          final cache = entry.value();
+          addTearDown(() {
+            if (cache case Disposable disposable) disposable.dispose();
+          });
+          var computes = 0;
+
+          final results = await Future.wait([
+            cache.getOrCompute('key', () async {
+              computes++;
+              await Future<void>.delayed(const Duration(milliseconds: 1));
+              return 'computed';
+            }),
+            cache.getOrCompute('key', () {
+              computes++;
+              return 'other';
+            }),
+          ]);
+
+          expect(results, equals(['computed', 'computed']));
+          expect(computes, equals(1));
+        },
+      );
+    }
+
+    test(
+      'monitored getOrCompute records miss for compute and hit for reuse',
+      () async {
+        final cache = MonitoredFIFOCache<String, String>(maxSize: 2);
+        addTearDown(cache.dispose);
+
+        expect(await cache.getOrCompute('key', () => 'computed'), 'computed');
+        expect(await cache.getOrCompute('key', () => 'other'), 'computed');
+
+        expect(cache.metrics.misses, equals(1));
+        expect(cache.metrics.hits, equals(1));
+      },
+    );
+  });
+
+  group('TTL getOrSet/getOrCompute()', () {
+    DateTime now = DateTime(2024);
+    DateTime clock() => now;
+
+    setUp(() {
+      now = DateTime(2024);
+    });
+
+    test('SimpleTTLCacheInterface applies ttl override to computed value', () {
+      final SimpleTTLCacheInterface<String, String> cache = SimpleTTLCache(
+        ttl: const Duration(seconds: 30),
+        clock: clock,
+      );
+
+      cache.getOrSet('short', () => 'value', ttl: const Duration(seconds: 5));
+      now = now.add(const Duration(seconds: 10));
+
+      expect(cache.get('short'), isNull);
+    });
+
+    test(
+      'ThreadSafeTTLCacheInterface applies ttl override to computed value',
+      () async {
+        final ThreadSafeTTLCacheInterface<String, String> cache = TTLCache(
+          ttl: const Duration(seconds: 30),
+          clock: clock,
+        );
+
+        await cache.getOrCompute(
+          'short',
+          () => 'value',
+          ttl: const Duration(seconds: 5),
+        );
+        now = now.add(const Duration(seconds: 10));
+
+        expect(await cache.get('short'), isNull);
+      },
+    );
+
+    test('MonitoredTTLCache records getOrCompute miss and hit', () async {
+      final cache = MonitoredTTLCache<String, String>(
+        ttl: const Duration(seconds: 30),
+        clock: clock,
+        alertConfig: CacheAlertConfig(notifyCallback: (_) {}),
+      );
+      addTearDown(cache.dispose);
+
+      expect(await cache.getOrCompute('key', () => 'value'), equals('value'));
+      expect(await cache.getOrCompute('key', () => 'other'), equals('value'));
+
+      expect(cache.metrics.misses, equals(1));
+      expect(cache.metrics.hits, equals(1));
+    });
+  });
+}

--- a/test/interfaces/cache_get_or_compute_test.dart
+++ b/test/interfaces/cache_get_or_compute_test.dart
@@ -1,6 +1,67 @@
 import 'package:cacherine/cacherine.dart';
 import 'package:test/test.dart';
 
+class _DefaultThreadSafeCache<K, V> extends ThreadSafeCache<K, V> {
+  final Map<K, V> _cache = {};
+
+  @override
+  Future<Iterable<K>> getKeys() async => _cache.keys.toList();
+
+  @override
+  Future<V?> get(K key) async => _cache[key];
+
+  @override
+  Future<bool> containsKey(K key) async => _cache.containsKey(key);
+
+  @override
+  Future<void> set(K key, V value) async {
+    _cache[key] = value;
+  }
+
+  @override
+  Future<void> remove(K key) async {
+    _cache.remove(key);
+  }
+
+  @override
+  Future<void> clear() async {
+    _cache.clear();
+  }
+}
+
+class _DefaultThreadSafeTTLCache<K, V>
+    extends ThreadSafeTTLCacheInterface<K, V> {
+  final Map<K, V> _cache = {};
+  final Map<K, Duration?> setTtls = {};
+
+  @override
+  Future<Iterable<K>> getKeys() async => _cache.keys.toList();
+
+  @override
+  Future<V?> get(K key) async => _cache[key];
+
+  @override
+  Future<bool> containsKey(K key) async => _cache.containsKey(key);
+
+  @override
+  Future<void> set(K key, V value, {Duration? ttl}) async {
+    _cache[key] = value;
+    setTtls[key] = ttl;
+  }
+
+  @override
+  Future<void> remove(K key) async {
+    _cache.remove(key);
+    setTtls.remove(key);
+  }
+
+  @override
+  Future<void> clear() async {
+    _cache.clear();
+    setTtls.clear();
+  }
+}
+
 void main() {
   group('SimpleCache.getOrSet()', () {
     final factories = <String, SimpleCache<String, String?> Function()>{
@@ -124,6 +185,99 @@ void main() {
         expect(cache.metrics.hits, equals(1));
       },
     );
+
+    test(
+      'default implementation returns existing value and computes missing value',
+      () async {
+        final cache = _DefaultThreadSafeCache<String, String?>();
+        var computes = 0;
+
+        await cache.set('present', null);
+
+        expect(
+          await cache.getOrCompute('present', () {
+            computes++;
+            return 'computed';
+          }),
+          isNull,
+        );
+        expect(
+          await cache.getOrCompute('missing', () {
+            computes++;
+            return 'computed';
+          }),
+          equals('computed'),
+        );
+
+        expect(computes, equals(1));
+        expect(await cache.get('missing'), equals('computed'));
+      },
+    );
+
+    test(
+      'capacity eviction branches run when getOrCompute inserts into full caches',
+      () async {
+        final caches = <String, ThreadSafeCache<String, String> Function()>{
+          'FIFOCache': () => FIFOCache(2),
+          'EphemeralFIFOCache': () => EphemeralFIFOCache(2),
+          'LRUCache': () => LRUCache(2),
+          'MRUCache': () => MRUCache(2),
+          'LFUCache': () => LFUCache(2),
+          'MonitoredFIFOCache': () => MonitoredFIFOCache(maxSize: 2),
+          'MonitoredEphemeralFIFOCache': () =>
+              MonitoredEphemeralFIFOCache(maxSize: 2),
+          'MonitoredLRUCache': () => MonitoredLRUCache(maxSize: 2),
+          'MonitoredMRUCache': () => MonitoredMRUCache(maxSize: 2),
+          'MonitoredLFUCache': () => MonitoredLFUCache(maxSize: 2),
+        };
+
+        for (final entry in caches.entries) {
+          final cache = entry.value();
+          addTearDown(() {
+            if (cache case Disposable disposable) disposable.dispose();
+          });
+
+          await cache.set('a', 'A');
+          await cache.set('b', 'B');
+
+          if (entry.key.contains('MRU') || entry.key.contains('LFU')) {
+            expect(await cache.get('a'), equals('A'));
+          }
+
+          expect(await cache.getOrCompute('c', () => 'C'), equals('C'));
+          expect(await cache.containsKey('c'), isTrue);
+          expect((await cache.getKeys()).length, equals(2));
+
+          final evictions = switch (cache) {
+            MonitoredFIFOCache<String, String>() =>
+              cache.metrics
+                  .snapshot(const Duration(minutes: 1))
+                  .evictionsPerMinute,
+            MonitoredEphemeralFIFOCache<String, String>() =>
+              cache.metrics
+                  .snapshot(const Duration(minutes: 1))
+                  .evictionsPerMinute,
+            MonitoredLRUCache<String, String>() =>
+              cache.metrics
+                  .snapshot(const Duration(minutes: 1))
+                  .evictionsPerMinute,
+            MonitoredMRUCache<String, String>() =>
+              cache.metrics
+                  .snapshot(const Duration(minutes: 1))
+                  .evictionsPerMinute,
+            MonitoredLFUCache<String, String>() =>
+              cache.metrics
+                  .snapshot(const Duration(minutes: 1))
+                  .evictionsPerMinute,
+            _ => null,
+          };
+
+          if (evictions != null) {
+            expect(evictions, equals(1), reason: entry.key);
+          }
+        }
+      },
+    );
   });
 
   group('TTL getOrSet/getOrCompute()', () {
@@ -165,6 +319,36 @@ void main() {
       },
     );
 
+    test(
+      'ThreadSafeTTLCacheInterface default implementation forwards ttl override',
+      () async {
+        final cache = _DefaultThreadSafeTTLCache<String, String?>();
+        var computes = 0;
+
+        await cache.set('present', null);
+
+        expect(
+          await cache.getOrCompute('present', () {
+            computes++;
+            return 'computed';
+          }, ttl: const Duration(seconds: 5)),
+          isNull,
+        );
+        expect(cache.setTtls['present'], isNull);
+
+        expect(
+          await cache.getOrCompute('missing', () {
+            computes++;
+            return 'computed';
+          }, ttl: const Duration(seconds: 5)),
+          equals('computed'),
+        );
+
+        expect(computes, equals(1));
+        expect(cache.setTtls['missing'], equals(const Duration(seconds: 5)));
+      },
+    );
+
     test('MonitoredTTLCache records getOrCompute miss and hit', () async {
       final cache = MonitoredTTLCache<String, String>(
         ttl: const Duration(seconds: 30),
@@ -179,5 +363,97 @@ void main() {
       expect(cache.metrics.misses, equals(1));
       expect(cache.metrics.hits, equals(1));
     });
+
+    test(
+      'TTLCache getOrCompute validates ttl and replaces expired entries',
+      () async {
+        final cache = TTLCache<String, String>(
+          ttl: const Duration(seconds: 30),
+          clock: clock,
+        );
+
+        await expectLater(
+          () =>
+              cache.getOrCompute('invalid', () => 'value', ttl: Duration.zero),
+          throwsArgumentError,
+        );
+
+        await cache.set('key', 'old', ttl: const Duration(seconds: 5));
+        now = now.add(const Duration(seconds: 10));
+
+        expect(await cache.getOrCompute('key', () => 'new'), equals('new'));
+        expect(await cache.get('key'), equals('new'));
+      },
+    );
+
+    test(
+      'TTLCache getOrCompute removes expired entries before capacity eviction',
+      () async {
+        final cache = TTLCache<String, String>(
+          ttl: const Duration(seconds: 5),
+          maxSize: 2,
+          clock: clock,
+        );
+
+        await cache.set('expired', 'old');
+        await cache.set('live', 'live', ttl: const Duration(seconds: 30));
+        now = now.add(const Duration(seconds: 10));
+
+        expect(await cache.getOrCompute('new', () => 'new'), equals('new'));
+        expect(await cache.getKeys(), equals(['live', 'new']));
+      },
+    );
+
+    test(
+      'MonitoredTTLCache getOrCompute validates ttl and records expired eviction',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 30),
+          clock: clock,
+          alertConfig: CacheAlertConfig(notifyCallback: (_) {}),
+        );
+        addTearDown(cache.dispose);
+
+        await expectLater(
+          () =>
+              cache.getOrCompute('invalid', () => 'value', ttl: Duration.zero),
+          throwsArgumentError,
+        );
+
+        await cache.set('key', 'old', ttl: const Duration(seconds: 5));
+        now = now.add(const Duration(seconds: 10));
+
+        expect(await cache.getOrCompute('key', () => 'new'), equals('new'));
+        expect(cache.metrics.misses, equals(1));
+        expect(
+          cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+          equals(1),
+        );
+      },
+    );
+
+    test(
+      'MonitoredTTLCache getOrCompute records expired cleanup during capacity check',
+      () async {
+        final cache = MonitoredTTLCache<String, String>(
+          ttl: const Duration(seconds: 5),
+          maxSize: 2,
+          clock: clock,
+          alertConfig: CacheAlertConfig(notifyCallback: (_) {}),
+        );
+        addTearDown(cache.dispose);
+
+        await cache.set('expired', 'old');
+        await cache.set('live', 'live', ttl: const Duration(seconds: 30));
+        now = now.add(const Duration(seconds: 10));
+
+        expect(await cache.getOrCompute('new', () => 'new'), equals('new'));
+        expect(await cache.getKeys(), equals(['live', 'new']));
+        expect(
+          cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+          equals(1),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## 📝 PR Summary

Adds cache-aside helper APIs for simple and async-safe caches, strengthens lifecycle and `getKeys()` contracts, and documents monitoring/metrics behavior for reviewers and users.

### 🐛 Bugfix | 🚀 Feature | 📖 Documentation Update | 🚀 Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [ ] Release

### 🔧 Fix / Feature Details

- **Issue:** Cache users currently need to manually perform `containsKey()` / `get()` / `set()` sequences when populating missing entries, which is repetitive and easy to make non-atomic for async-safe caches. The `dispose()` and `getKeys()` contracts were also not fully documented or tested across cache variants.
- **Fix / Feature:** Added `getOrSet()` to `SimpleCache` and `getOrCompute()` to `ThreadSafeCache`, with TTL override support through `SimpleTTLCacheInterface` and `ThreadSafeTTLCacheInterface`. Async-safe implementations override `getOrCompute()` so check/compute/store runs through the cache lock. Monitored caches record hit/miss and latency for `getOrCompute()`. Added regression tests for compute helpers, nullable stored values, concurrent compute serialization, disposable lifecycle behavior, and `getKeys()` ordering contracts.

### 📌 Related Issue

N/A

---

## 🔍 Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests (if applicable)

```sh
/Users/yotahara/fvm/versions/stable/bin/dart format .
/Users/yotahara/fvm/versions/stable/bin/dart analyze --fatal-infos
/Users/yotahara/fvm/versions/stable/bin/dart test test/interfaces/cache_get_or_compute_test.dart test/caches/disposable_lifecycle_test.dart test/caches/get_keys_order_test.dart
/Users/yotahara/fvm/versions/stable/bin/dart test
/Users/yotahara/fvm/versions/stable/bin/dart test --coverage=coverage/
/Users/yotahara/fvm/versions/stable/bin/dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
```

Coverage check: `1007/1058` lines covered (`95.18%`) locally after generating `coverage/lcov.info`.

---

## 📖 Documentation Update (if applicable)

### 🔧 Documentation Changes

- [x] Updated README
- [x] Updated API reference
- [ ] Added new guides/tutorials

### 🚀 Additional Notes

- Updated cache guide docs for FIFO, Ephemeral FIFO, LRU, MRU, LFU, TTL, and monitored caches.
- Documented `Disposable` lifecycle behavior, `getKeys()` ordering contracts, `getOrSet()` / `getOrCompute()` semantics, monitored helper metrics, and bounded `CacheMetrics` sample storage.
- Added `PR_SUMMARY.md` to `.gitignore`; this file is intended as a local PR drafting aid and is not included in the commit.

---

## 🚀 Release Checklist (if applicable)

### 📌 Release Checklist

- [ ] **Bump version in `pubspec.yaml`**
- [x] **Update `CHANGELOG.md` with release notes**
- [x] **Update `README.md` if necessary**
- [x] **Run `dart analyze` to ensure no issues**
- [x] **Run `dart test` to confirm all tests pass**
- [ ] **Ensure all dependencies are up to date**
- [ ] **Tag the release commit after merging**

<!-- Release Summary -->
<!--
### 📝 Release Summary
[//]: # "Provide a summary of this release (e.g., major changes, bug fixes, improvements)"

### 🔧 Release Changes

- [ ] Feature A
- [ ] Improvement B
- [ ] Bugfix C

### 🏷 Versioning

- **Current Version:** `X.Y.Z`
- **New Version:** `X.Y.Z+1`

### 🚀 Additional Notes

[//]: # "Any additional context, related issues, or references"
-->
