### PR TITLE
Prepare 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 2.2.0 - Simple TTL Cache, Cache-Aside Helpers, and Contract Coverage
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Check the latest version on [pub.dev](https://pub.dev/packages/cacherine) and ad
 
 ```yaml
 dependencies:
-  cacherine: ^2.1.0
+  cacherine: ^2.2.0
 ```
 
 Then, run the following command in your terminal:

--- a/doc/ephemeral_fifo_cache.md
+++ b/doc/ephemeral_fifo_cache.md
@@ -52,7 +52,16 @@ The eviction policy of the Ephemeral FIFO Cache follows these rules:
 `getKeys()` returns the remaining keys in FIFO insertion order. Keys already
 retrieved by `get()` are removed from the cache and are not included.
 
-### 3.4 Example: Ephemeral FIFO Cache Operations and State Changes
+### 3.4 Cache-Aside Population (`getOrSet` / `getOrCompute`)
+
+Use `getOrSet()` on `SimpleEphemeralFIFOCache` or `getOrCompute()` on
+`EphemeralFIFOCache` and `MonitoredEphemeralFIFOCache` to return an existing
+value, or compute and store a value when the key is missing. Existing keys are
+treated as successful reads and are removed after returning. Newly computed
+values are inserted like `set()` and can trigger FIFO eviction when the cache is
+full.
+
+### 3.5 Example: Ephemeral FIFO Cache Operations and State Changes
 
 1. Initial State: EphemeralFIFOCache<maxCount: 3>
 

--- a/doc/fifo_cache.md
+++ b/doc/fifo_cache.md
@@ -45,7 +45,15 @@ The FIFO Cache eviction policy follows these rules:
 `getKeys()` returns keys in FIFO insertion order. Updating an existing key
 changes its value but keeps its current position.
 
-### 3.4 Example: FIFO Cache Operations and State Changes
+### 3.4 Cache-Aside Population (`getOrSet` / `getOrCompute`)
+
+Use `getOrSet()` on `SimpleFIFOCache` or `getOrCompute()` on `FIFOCache` and
+`MonitoredFIFOCache` to return an existing value, or compute and store a value
+when the key is missing. Existing keys keep their FIFO position. Newly computed
+values are inserted like `set()` and can trigger FIFO eviction when the cache is
+full.
+
+### 3.5 Example: FIFO Cache Operations and State Changes
 
 1. Initial State: FIFOCache<maxCount: 3>
 

--- a/doc/lfu_cache.md
+++ b/doc/lfu_cache.md
@@ -48,7 +48,15 @@ The LFU Cache eviction policy follows these rules:
 `getKeys()` returns a snapshot of current keys, but the order is unspecified.
 Do not use it to infer frequency, recency, or eviction order.
 
-### 3.4 Example: LFUCache operations and state changes
+### 3.4 Cache-Aside Population (`getOrSet` / `getOrCompute`)
+
+Use `getOrSet()` on `SimpleLFUCache` or `getOrCompute()` on `LFUCache` and
+`MonitoredLFUCache` to return an existing value, or compute and store a value
+when the key is missing. Existing keys are treated as successful reads and their
+frequency is incremented. Newly computed values are inserted like `set()` with
+an initial frequency of 1 and can trigger LFU eviction when the cache is full.
+
+### 3.5 Example: LFUCache operations and state changes
 
 1. Initial state: LFUCache<maxCount: 3>
 

--- a/doc/lru_cache.md
+++ b/doc/lru_cache.md
@@ -45,7 +45,15 @@ The eviction policy of an LRU Cache follows these rules:
 `getKeys()` returns keys from least recently used to most recently used. A
 successful `get()` or `set()` of an existing key moves that key to the end.
 
-### 3.4 Example: LRUCache Operations and State Changes
+### 3.4 Cache-Aside Population (`getOrSet` / `getOrCompute`)
+
+Use `getOrSet()` on `SimpleLRUCache` or `getOrCompute()` on `LRUCache` and
+`MonitoredLRUCache` to return an existing value, or compute and store a value
+when the key is missing. Existing keys are treated as successful reads and move
+to the most recently used position. Newly computed values are inserted like
+`set()` and can trigger LRU eviction when the cache is full.
+
+### 3.5 Example: LRUCache Operations and State Changes
 
 1. Initial State: LRUCache<maxCount: 3>
 

--- a/doc/mru_cache.md
+++ b/doc/mru_cache.md
@@ -46,7 +46,15 @@ The eviction policy of MRU Cache follows these rules:
 last key in the snapshot is the next eviction candidate if a new key is inserted
 while the cache is full.
 
-### 3.4 Example: MRUCache Operations and State Changes
+### 3.4 Cache-Aside Population (`getOrSet` / `getOrCompute`)
+
+Use `getOrSet()` on `SimpleMRUCache` or `getOrCompute()` on `MRUCache` and
+`MonitoredMRUCache` to return an existing value, or compute and store a value
+when the key is missing. Existing keys are treated as successful reads and move
+to the most recently used position. Newly computed values are inserted like
+`set()` and can trigger MRU eviction when the cache is full.
+
+### 3.5 Example: MRUCache Operations and State Changes
 
 1. Initial State: MRUCache<maxCount: 3>
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cacherine
 description: A Dart in-memory cache library with FIFO, LRU, MRU, LFU, TTL expiry, async-safe variants, and monitoring metrics.
-version: 2.1.0
+version: 2.2.0
 repository: https://github.com/yordgenome03/cacherine
 
 environment:


### PR DESCRIPTION
## 📝 PR Summary

Prepares the `2.2.0` release with cache-aside helper APIs for simple and async-safe caches, strengthened lifecycle and `getKeys()` contracts, and updated documentation for reviewers and users.

### 🐛 Bugfix | 🚀 Feature | 📖 Documentation Update | 🚀 Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [x] Release

### 🔧 Fix / Feature Details

- **Issue:** Cache users currently need to manually perform `containsKey()` / `get()` / `set()` sequences when populating missing entries, which is repetitive and easy to make non-atomic for async-safe caches. The `dispose()` and `getKeys()` contracts were also not fully documented or tested across cache variants.
- **Fix / Feature:** Added `getOrSet()` to `SimpleCache` and `getOrCompute()` to `ThreadSafeCache`, with TTL override support through `SimpleTTLCacheInterface` and `ThreadSafeTTLCacheInterface`. Async-safe implementations override `getOrCompute()` so check/compute/store runs through the cache lock. Monitored caches record hit/miss and latency for `getOrCompute()`. Added regression tests for compute helpers, nullable stored values, concurrent compute serialization, disposable lifecycle behavior, and `getKeys()` ordering contracts.

### 📌 Related Issue

N/A

---

## 🔍 Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests (if applicable)

```sh
/Users/yotahara/fvm/versions/stable/bin/dart format .
/Users/yotahara/fvm/versions/stable/bin/dart analyze --fatal-infos
/Users/yotahara/fvm/versions/stable/bin/dart test test/interfaces/cache_get_or_compute_test.dart test/caches/disposable_lifecycle_test.dart test/caches/get_keys_order_test.dart
/Users/yotahara/fvm/versions/stable/bin/dart test
/Users/yotahara/fvm/versions/stable/bin/dart test --coverage=coverage/
/Users/yotahara/fvm/versions/stable/bin/dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
```

Coverage check: `1007/1058` lines covered (`95.18%`) locally after generating `coverage/lcov.info`.

---

## 📖 Documentation Update (if applicable)

### 🔧 Documentation Changes

- [x] Updated README
- [x] Updated API reference
- [ ] Added new guides/tutorials

### 🚀 Additional Notes

- Updated cache guide docs for FIFO, Ephemeral FIFO, LRU, MRU, LFU, TTL, and monitored caches.
- Documented `Disposable` lifecycle behavior, `getKeys()` ordering contracts, `getOrSet()` / `getOrCompute()` semantics, monitored helper metrics, and bounded `CacheMetrics` sample storage.
- Updated cache guide docs for FIFO, Ephemeral FIFO, LRU, MRU, and LFU with cache-aside helper semantics.
- `PR_SUMMARY.md` remains a local drafting aid and is not included in the release commits.

---

## 🚀 Release Checklist (if applicable)

### 📌 Release Checklist

- [x] **Bump version in `pubspec.yaml`**
- [x] **Update `CHANGELOG.md` with release notes**
- [x] **Update `README.md` if necessary**
- [x] **Run `dart analyze` to ensure no issues**
- [x] **Run `dart test` to confirm all tests pass**
- [x] **Ensure all dependencies are up to date**
- [ ] **Tag the release commit after merging**

<!-- Release Summary -->

### 📝 Release Summary
Release `2.2.0` adds cache-aside helper APIs, synchronous TTL cache support, TTL-specific interfaces, and documentation/test coverage for cache lifecycle and key-order contracts.

### 🔧 Release Changes

- [x] Add `getOrSet()` to simple caches and `getOrCompute()` to async-safe caches
- [x] Add `SimpleTTLCache`, `SimpleTTLCacheInterface`, and `ThreadSafeTTLCacheInterface`
- [x] Document cache-aside semantics, TTL abstractions, `getKeys()` ordering, `Disposable` lifecycle, and bounded metrics storage

### 🏷 Versioning

- **Current Version:** `2.1.0`
- **New Version:** `2.2.0`

### 🚀 Additional Notes

- Release branch: `release/2.2.0`
- Verification: `dart analyze --fatal-infos`, `dart test`, `dart pub outdated`, and `dart pub publish --dry-run`
- `dart pub publish --dry-run` only reported the expected warning about publishing from a dirty git state before release commits were finalized.
