### PR TITLE
test: add cache interface state contract coverage

### DIFF
--- a/test/interfaces/cache_state_contract_test.dart
+++ b/test/interfaces/cache_state_contract_test.dart
@@ -1,0 +1,150 @@
+import 'package:cacherine/cacherine.dart';
+import 'package:test/test.dart';
+
+class _DefaultSimpleCache<K, V> extends SimpleCache<K, V> {
+  final Map<K, V> _cache = {};
+
+  @override
+  Iterable<K> getKeys() => _cache.keys.toList();
+
+  @override
+  V? get(K key) => _cache[key];
+
+  @override
+  bool containsKey(K key) => _cache.containsKey(key);
+
+  @override
+  void set(K key, V value) {
+    _cache[key] = value;
+  }
+
+  @override
+  void remove(K key) {
+    _cache.remove(key);
+  }
+
+  @override
+  void clear() {
+    _cache.clear();
+  }
+}
+
+class _DefaultThreadSafeCache<K, V> extends ThreadSafeCache<K, V> {
+  final Map<K, V> _cache = {};
+
+  @override
+  Future<Iterable<K>> getKeys() async => _cache.keys.toList();
+
+  @override
+  Future<V?> get(K key) async => _cache[key];
+
+  @override
+  Future<bool> containsKey(K key) async => _cache.containsKey(key);
+
+  @override
+  Future<void> set(K key, V value) async {
+    _cache[key] = value;
+  }
+
+  @override
+  Future<void> remove(K key) async {
+    _cache.remove(key);
+  }
+
+  @override
+  Future<void> clear() async {
+    _cache.clear();
+  }
+}
+
+void main() {
+  group('SimpleCache state contract', () {
+    test('default occupancy getters derive from getKeys()', () {
+      final cache = _DefaultSimpleCache<String, String>();
+
+      expect(cache.size, equals(0));
+      expect(cache.isEmpty, isTrue);
+      expect(cache.isNotEmpty, isFalse);
+
+      cache.set('a', 'A');
+      cache.set('b', 'B');
+
+      expect(cache.size, equals(2));
+      expect(cache.isEmpty, isFalse);
+      expect(cache.isNotEmpty, isTrue);
+    });
+
+    test('peek does not consume SimpleEphemeralFIFOCache entries', () {
+      final SimpleCache<String, String> cache =
+          SimpleEphemeralFIFOCache<String, String>(2);
+
+      cache.set('a', 'A');
+
+      expect(cache.peek('a'), equals('A'));
+      expect(cache.get('a'), equals('A'));
+      expect(cache.containsKey('a'), isFalse);
+    });
+
+    test('peek does not update SimpleLRUCache recency', () {
+      final SimpleCache<String, String> cache = SimpleLRUCache<String, String>(
+        2,
+      );
+
+      cache.set('a', 'A');
+      cache.set('b', 'B');
+      expect(cache.peek('a'), equals('A'));
+      cache.set('c', 'C');
+
+      expect(cache.containsKey('a'), isFalse);
+      expect(cache.containsKey('b'), isTrue);
+      expect(cache.containsKey('c'), isTrue);
+    });
+
+    test('peek does not update SimpleMRUCache recency', () {
+      final SimpleCache<String, String> cache = SimpleMRUCache<String, String>(
+        2,
+      );
+
+      cache.set('a', 'A');
+      cache.set('b', 'B');
+      expect(cache.peek('a'), equals('A'));
+      cache.set('c', 'C');
+
+      expect(cache.containsKey('a'), isTrue);
+      expect(cache.containsKey('b'), isFalse);
+      expect(cache.containsKey('c'), isTrue);
+    });
+
+    test('peek does not increment SimpleLFUCache frequency', () {
+      final SimpleCache<String, String> cache = SimpleLFUCache<String, String>(
+        2,
+      );
+
+      cache.set('a', 'A');
+      cache.set('b', 'B');
+      expect(cache.peek('a'), equals('A'));
+      cache.set('c', 'C');
+
+      expect(cache.containsKey('a'), isFalse);
+      expect(cache.containsKey('b'), isTrue);
+      expect(cache.containsKey('c'), isTrue);
+    });
+  });
+
+  group('ThreadSafeCache state contract', () {
+    test('default occupancy getters derive from getKeys()', () async {
+      final cache = _DefaultThreadSafeCache<String, String>();
+
+      expect(await cache.size, equals(0));
+      expect(await cache.isEmpty, isTrue);
+      expect(await cache.isNotEmpty, isFalse);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+
+      expect(await cache.size, equals(2));
+      expect(await cache.isEmpty, isFalse);
+      expect(await cache.isNotEmpty, isTrue);
+    });
+  });
+}

--- a/test/interfaces/ttl_cache_interfaces_test.dart
+++ b/test/interfaces/ttl_cache_interfaces_test.dart
@@ -52,6 +52,7 @@ void main() {
 
       expect(cache.purgeExpired(), equals(1));
       expect(cache.getKeys(), equals(['live']));
+      expect(cache.purgeExpired(), equals(0));
     });
 
     test('validates per-entry TTL overrides through the interface', () {
@@ -125,6 +126,7 @@ void main() {
 
         expect(await cache.purgeExpired(), equals(1));
         expect(await cache.getKeys(), equals(['live']));
+        expect(await cache.purgeExpired(), equals(0));
       },
     );
 
@@ -147,6 +149,13 @@ void main() {
 
         expect(await ttlCache.purgeExpired(), equals(1));
         expect(await ttlCache.getKeys(), equals(['live']));
+        expect(await ttlCache.purgeExpired(), equals(0));
+        expect(
+          cache.metrics.snapshot(const Duration(minutes: 1)).evictionsPerMinute,
+          equals(1),
+        );
+        expect(cache.metrics.hits, equals(0));
+        expect(cache.metrics.misses, equals(0));
       },
     );
 


### PR DESCRIPTION
 ## 📝 PR Summary

  Adds regression coverage for cache interface state contracts around `peek()`, occupancy getters, and TTL expiry purge behavior.

  ### 🐛 Bugfix | 🚀 Feature | 📖 Documentation Update | 🚀 Release

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Documentation Update
  - [ ] Release

  ### 🔧 Fix / Feature Details

  - **Issue:** Recently added cache state APIs rely on consistent behavior through public interfaces, but some interface-level
  contracts were only covered indirectly by implementation-specific tests.
  - **Fix / Feature:** Added interface contract tests for `SimpleCache` and `ThreadSafeCache` occupancy getters, verified `peek()`
  does not mutate simple cache eviction state through the `SimpleCache` interface, and tightened TTL interface `purgeExpired()`
  coverage for idempotent return values and monitored eviction metrics.

  ### 📌 Related Issue

  N/A

  ---

  ## 🔍 Testing

  - [x] Unit tests passed
  - [x] Manually verified expected behavior
  - [x] Added regression tests (if applicable)

  Verified with:

  ```bash
  /Users/yotahara/fvm/versions/stable/bin/dart test test/interfaces
  /Users/yotahara/fvm/versions/stable/bin/dart format --output=none --set-exit-if-changed .
  /Users/yotahara/fvm/versions/stable/bin/dart analyze --fatal-infos
  /Users/yotahara/fvm/versions/stable/bin/dart test

  ———

  ## 📖 Documentation Update (if applicable)

  ### 🔧 Documentation Changes

  - [ ] Updated README
  - [ ] Updated API reference
  - [ ] Added new guides/tutorials

  ### 🚀 Additional Notes

  No documentation changes. This PR only adds regression coverage.

  ———

  ## 🚀 Release Checklist (if applicable)
  <!-- This PR is for a new release. Please ensure all steps below are completed. -->

  ### 📌 Release Checklist

  - [ ] Bump version in pubspec.yaml
  - [ ] Update CHANGELOG.md with release notes
  - [ ] Update README.md if necessary
  - [x] Run dart analyze to ensure no issues
  - [x] Run dart test to confirm all tests pass
  - [ ] Ensure all dependencies are up to date
  - [ ] Tag the release commit after merging