### PR TITLE
Prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-## Unreleased
+## 2.3.0 - Peek, Occupancy APIs, and TTL Purge Cleanup
 
 ### Documentation
 
 - Expanded the runnable example and README cache-aside snippets to cover both `getOrSet()` and TTL-aware `getOrCompute()`.
 - Documented the non-mutating `peek()` API across README and cache guides.
+- Documented occupancy APIs (`size`, `isEmpty`, and `isNotEmpty`) across README and cache guides.
 - Documented explicit TTL expiry cleanup with `purgeExpired()`.
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check the latest version on [pub.dev](https://pub.dev/packages/cacherine) and ad
 
 ```yaml
 dependencies:
-  cacherine: ^2.2.0
+  cacherine: ^2.3.0
 ```
 
 Then, run the following command in your terminal:

--- a/doc/ephemeral_fifo_cache.md
+++ b/doc/ephemeral_fifo_cache.md
@@ -66,7 +66,13 @@ treated as successful reads and are removed after returning. Newly computed
 values are inserted like `set()` and can trigger FIFO eviction when the cache is
 full.
 
-### 3.6 Example: Ephemeral FIFO Cache Operations and State Changes
+### 3.6 Occupancy (`size` / `isEmpty` / `isNotEmpty` operations)
+
+`size`, `isEmpty`, and `isNotEmpty` report the current number of cached entries
+without removing entries. Monitored ephemeral FIFO caches do not record
+hit/miss/latency metrics for these reads.
+
+### 3.7 Example: Ephemeral FIFO Cache Operations and State Changes
 
 1. Initial State: EphemeralFIFOCache<maxCount: 3>
 

--- a/doc/fifo_cache.md
+++ b/doc/fifo_cache.md
@@ -58,7 +58,13 @@ when the key is missing. Existing keys keep their FIFO position. Newly computed
 values are inserted like `set()` and can trigger FIFO eviction when the cache is
 full.
 
-### 3.6 Example: FIFO Cache Operations and State Changes
+### 3.6 Occupancy (`size` / `isEmpty` / `isNotEmpty` operations)
+
+`size`, `isEmpty`, and `isNotEmpty` report the current number of cached entries
+without changing FIFO insertion order. Monitored FIFO caches do not record
+hit/miss/latency metrics for these reads.
+
+### 3.7 Example: FIFO Cache Operations and State Changes
 
 1. Initial State: FIFOCache<maxCount: 3>
 

--- a/doc/lfu_cache.md
+++ b/doc/lfu_cache.md
@@ -62,7 +62,13 @@ when the key is missing. Existing keys are treated as successful reads and their
 frequency is incremented. Newly computed values are inserted like `set()` with
 an initial frequency of 1 and can trigger LFU eviction when the cache is full.
 
-### 3.6 Example: LFUCache operations and state changes
+### 3.6 Occupancy (`size` / `isEmpty` / `isNotEmpty` operations)
+
+`size`, `isEmpty`, and `isNotEmpty` report the current number of cached entries
+without incrementing frequency or changing recency within frequency buckets.
+Monitored LFU caches do not record hit/miss/latency metrics for these reads.
+
+### 3.7 Example: LFUCache operations and state changes
 
 1. Initial state: LFUCache<maxCount: 3>
 

--- a/doc/lru_cache.md
+++ b/doc/lru_cache.md
@@ -58,7 +58,13 @@ when the key is missing. Existing keys are treated as successful reads and move
 to the most recently used position. Newly computed values are inserted like
 `set()` and can trigger LRU eviction when the cache is full.
 
-### 3.6 Example: LRUCache Operations and State Changes
+### 3.6 Occupancy (`size` / `isEmpty` / `isNotEmpty` operations)
+
+`size`, `isEmpty`, and `isNotEmpty` report the current number of cached entries
+without changing recency order. Monitored LRU caches do not record
+hit/miss/latency metrics for these reads.
+
+### 3.7 Example: LRUCache Operations and State Changes
 
 1. Initial State: LRUCache<maxCount: 3>
 

--- a/doc/mru_cache.md
+++ b/doc/mru_cache.md
@@ -59,7 +59,13 @@ when the key is missing. Existing keys are treated as successful reads and move
 to the most recently used position. Newly computed values are inserted like
 `set()` and can trigger MRU eviction when the cache is full.
 
-### 3.6 Example: MRUCache Operations and State Changes
+### 3.6 Occupancy (`size` / `isEmpty` / `isNotEmpty` operations)
+
+`size`, `isEmpty`, and `isNotEmpty` report the current number of cached entries
+without changing recency order. Monitored MRU caches do not record
+hit/miss/latency metrics for these reads.
+
+### 3.7 Example: MRUCache Operations and State Changes
 
 1. Initial State: MRUCache<maxCount: 3>
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cacherine
 description: A Dart in-memory cache library with FIFO, LRU, MRU, LFU, TTL expiry, async-safe variants, and monitoring metrics.
-version: 2.2.0
+version: 2.3.0
 repository: https://github.com/yordgenome03/cacherine
 
 environment:


### PR DESCRIPTION
## 📝 PR Summary

Prepare the `cacherine` 2.3.0 release for the new non-mutating read, occupancy,
and explicit TTL cleanup APIs.

### 🐛 Bugfix | 🚀 Feature | 📖 Documentation Update | 🚀 Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [x] Release

### 🔧 Fix / Feature Details

- **Issue:** The package had unreleased API additions for `peek()`, occupancy
  getters, and explicit TTL expiry cleanup that needed to be finalized for a
  published release.
- **Fix / Feature:** Bumped the package to `2.3.0`, finalized the changelog,
  updated the README installation example, and documented `size`, `isEmpty`,
  and `isNotEmpty` behavior across the cache guides.

### 📌 Related Issue

N/A

---

## 🔍 Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests (if applicable)

Validated with:

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test`
- `dart pub publish --dry-run`

---

## 📖 Documentation Update (if applicable)

### 🔧 Documentation Changes

- [x] Updated README
- [x] Updated API reference
- [x] Added new guides/tutorials

### 🚀 Additional Notes

Updated the FIFO, Ephemeral FIFO, LRU, MRU, LFU, TTL, and monitored cache
documentation for the 2.3.0 API surface.

---

## 🚀 Release Checklist (if applicable)

### 📌 Release Checklist

- [x] **Bump version in `pubspec.yaml`**
- [x] **Update `CHANGELOG.md` with release notes**
- [x] **Update `README.md` if necessary**
- [x] **Run `dart analyze` to ensure no issues**
- [x] **Run `dart test` to confirm all tests pass**
- [x] **Ensure all dependencies are up to date**
- [ ] **Tag the release commit after merging**

<!-- Release Summary -->
<!-- 
### 📝 Release Summary
[//]: # "Provide a summary of this release (e.g., major changes, bug fixes, improvements)"

### 🔧 Release Changes

- [x] Add non-mutating `peek()` reads across cache variants
- [x] Add occupancy APIs: `size`, `isEmpty`, and `isNotEmpty`
- [x] Add explicit TTL cleanup with `purgeExpired()`
- [x] Update release documentation for 2.3.0

### 🏷 Versioning

- **Current Version:** `2.2.0`
- **New Version:** `2.3.0`

### 🚀 Additional Notes

[//]: # "Any additional context, related issues, or references"
-->
