### PR TITLE
Add bulk cache operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,18 @@
 
 - Added `putIfAbsent()`, `update()`, and `removeWhere()` default APIs to simple, async-safe, and TTL cache interfaces.
 - Added TTL-aware `putIfAbsent()` and `update()` overloads so new or updated entries can receive per-entry TTL overrides through TTL abstractions.
+- Added `getAll()`, `setAll()`, and `removeAll()` bulk operation APIs to simple, async-safe, and TTL cache interfaces.
+- Added TTL-aware `setAll()` overloads so batches can receive a shared per-entry TTL override through TTL abstractions.
 
 ### Documentation
 
 - Documented conditional mutation helpers and clarified `getOrCompute()` same-instance serialization semantics.
+- Documented bulk operation helpers and their cache policy side effects.
 
 ### Maintenance
 
 - Added injectable clock support to `CacheMetrics` for deterministic eviction-window and dashboard tests.
-- Expanded contract coverage for conditional mutation helpers, TTL helper forwarding, and TTL `getOrCompute()` concurrent computation behavior.
+- Expanded contract coverage for conditional mutation helpers, bulk operations, TTL helper forwarding, and TTL `getOrCompute()` concurrent computation behavior.
 
 ## 2.3.0 - Peek, Occupancy APIs, and TTL Purge Cleanup
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Whether you need a simple synchronous cache or an async-compatible solution that
 - **`size`, `isEmpty`, and `isNotEmpty` support** (reads cache occupancy without recording monitored traffic metrics)
 - **`purgeExpired()` support for TTL caches** (explicitly removes expired TTL entries and returns the number removed)
 - **Conditional mutation helpers**: `putIfAbsent()`, `update()`, and `removeWhere()` for cache-aside writes, targeted updates, and predicate-based cleanup
+- **Bulk operations**: `getAll()`, `setAll()`, and `removeAll()` for multi-key reads, writes, and invalidation
 - **Simple versions (e.g., SimpleFIFOCache) for synchronous usage, and standard versions that serialize concurrent async calls within the same isolate**
 
 ## Installation
@@ -136,6 +137,17 @@ await cache.update('requests', (value) => value + 1);
 await cache.removeWhere((key, value) => value == 0);
 ```
 
+Use `getAll()`, `setAll()`, and `removeAll()` when you need to read, warm, or
+invalidate multiple keys:
+
+```dart
+final cache = LRUCache<String, String>(100);
+
+await cache.setAll({'user:1': 'Ada', 'user:2': 'Linus'});
+final users = await cache.getAll(['user:1', 'missing', 'user:2']);
+await cache.removeAll(users.keys);
+```
+
 ### TTL Usage
 
 Entries expire automatically once their TTL elapses. Use `ttl:` on individual `set()` calls to override the global default for a single entry.
@@ -215,6 +227,13 @@ Use `peek()` when you need to read a value without changing cache policy state. 
 `getOrSet()`, `getOrCompute()`, and `putIfAbsent()` use `containsKey()` semantics before reading, so stored `null` values are treated as present. Package async-safe cache implementations serialize the check/compute/store sequence on the same cache instance, so concurrent calls for the same missing key compute once and later callers observe the stored value. On monitored caches, `getOrCompute()` records one hit when the key already exists and one miss when the callback is used to populate the key.
 
 `update()` changes an existing value or stores `ifAbsent()` when provided. It throws `StateError` for missing keys when `ifAbsent` is omitted. `removeWhere()` iterates a key snapshot and reads candidate values with `peek()`, so it does not update LRU/MRU order, increment LFU frequency, or consume EphemeralFIFO entries while deciding what to remove.
+
+`getAll()` returns a map containing only currently present keys. Stored `null`
+values are included when `V` is nullable. Each present key is read with `get()`,
+so eviction policy side effects match repeated single-key reads. `setAll()` and
+`removeAll()` apply the same behavior as repeated `set()` and `remove()` calls.
+TTL abstractions accept `ttl:` on `setAll()` to apply the same per-entry TTL to
+all inserted entries.
 
 `getKeys()` returns a snapshot. FIFO and TTL caches return insertion order for live entries. LRU and MRU caches return least-to-most recently used order. Ephemeral FIFO caches omit entries already consumed by `get()`. LFU cache key order is unspecified.
 

--- a/lib/src/interfaces/simple_cache.dart
+++ b/lib/src/interfaces/simple_cache.dart
@@ -41,7 +41,10 @@ abstract class SimpleCache<K, V> {
     final values = <K, V>{};
     for (final key in keys) {
       if (containsKey(key)) {
-        values[key] = get(key) as V;
+        final value = get(key);
+        if (value != null || null is V) {
+          values[key] = value as V;
+        }
       }
     }
     return values;

--- a/lib/src/interfaces/simple_cache.dart
+++ b/lib/src/interfaces/simple_cache.dart
@@ -30,6 +30,23 @@ abstract class SimpleCache<K, V> {
   /// **Returns:** The value associated with the key, or `null`.
   V? get(K key);
 
+  /// **Retrieves values for all currently present [keys].**
+  ///
+  /// Missing keys are omitted from the returned map. Stored `null` values are
+  /// included when `V` is nullable.
+  ///
+  /// Implementations that update access state from [get] apply the same access
+  /// behavior for each present key.
+  Map<K, V> getAll(Iterable<K> keys) {
+    final values = <K, V>{};
+    for (final key in keys) {
+      if (containsKey(key)) {
+        values[key] = get(key) as V;
+      }
+    }
+    return values;
+  }
+
   /// **Retrieves the value for [key] without updating cache access state.**
   ///
   /// This method returns `null` if the key does not exist. Package cache
@@ -59,6 +76,16 @@ abstract class SimpleCache<K, V> {
   /// - `key`: The key for the data to store.
   /// - `value`: The value of the data to store.
   void set(K key, V value);
+
+  /// **Stores all key-value pairs from [entries].**
+  ///
+  /// Each entry follows the same behavior as [set], including eviction policy
+  /// effects.
+  void setAll(Map<K, V> entries) {
+    for (final entry in entries.entries) {
+      set(entry.key, entry.value);
+    }
+  }
 
   /// **Returns the existing value for [key], or stores and returns a new one.**
   ///
@@ -109,6 +136,15 @@ abstract class SimpleCache<K, V> {
   /// **Arguments:**
   /// - `key`: The key of the entry to remove.
   void remove(K key);
+
+  /// **Removes all entries with keys in [keys].**
+  ///
+  /// Missing keys are ignored.
+  void removeAll(Iterable<K> keys) {
+    for (final key in keys) {
+      remove(key);
+    }
+  }
 
   /// **Removes all entries that match [test].**
   ///

--- a/lib/src/interfaces/simple_ttl_cache.dart
+++ b/lib/src/interfaces/simple_ttl_cache.dart
@@ -17,6 +17,17 @@ abstract class SimpleTTLCacheInterface<K, V> extends SimpleCache<K, V> {
   @override
   void set(K key, V value, {Duration? ttl});
 
+  /// **Stores all key-value pairs from [entries].**
+  ///
+  /// - If [ttl] is omitted, the cache implementation's default TTL is used.
+  /// - If a key already exists, its value and expiry are updated.
+  @override
+  void setAll(Map<K, V> entries, {Duration? ttl}) {
+    for (final entry in entries.entries) {
+      set(entry.key, entry.value, ttl: ttl);
+    }
+  }
+
   /// **Returns the existing value for [key], or stores and returns a new one.**
   ///
   /// When a new value is stored, [ttl] overrides the implementation's default

--- a/lib/src/interfaces/thread_safe_cache.dart
+++ b/lib/src/interfaces/thread_safe_cache.dart
@@ -45,7 +45,10 @@ abstract class ThreadSafeCache<K, V> {
     final values = <K, V>{};
     for (final key in keys) {
       if (await containsKey(key)) {
-        values[key] = await get(key) as V;
+        final value = await get(key);
+        if (value != null || null is V) {
+          values[key] = value as V;
+        }
       }
     }
     return values;

--- a/lib/src/interfaces/thread_safe_cache.dart
+++ b/lib/src/interfaces/thread_safe_cache.dart
@@ -34,6 +34,23 @@ abstract class ThreadSafeCache<K, V> {
   /// **Returns:** `Future<V?>` (The value associated with the key, or `null`).
   Future<V?> get(K key);
 
+  /// **Retrieves values for all currently present [keys].**
+  ///
+  /// Missing keys are omitted from the returned map. Stored `null` values are
+  /// included when `V` is nullable.
+  ///
+  /// Implementations that update access state from [get] apply the same access
+  /// behavior for each present key.
+  Future<Map<K, V>> getAll(Iterable<K> keys) async {
+    final values = <K, V>{};
+    for (final key in keys) {
+      if (await containsKey(key)) {
+        values[key] = await get(key) as V;
+      }
+    }
+    return values;
+  }
+
   /// **Retrieves the value for [key] without updating cache access state.**
   ///
   /// This method returns `null` if the key does not exist. Package cache
@@ -63,6 +80,16 @@ abstract class ThreadSafeCache<K, V> {
   /// - `key`: The key for the data to store.
   /// - `value`: The value of the data to store.
   Future<void> set(K key, V value);
+
+  /// **Stores all key-value pairs from [entries].**
+  ///
+  /// Each entry follows the same behavior as [set], including eviction policy
+  /// effects.
+  Future<void> setAll(Map<K, V> entries) async {
+    for (final entry in entries.entries) {
+      await set(entry.key, entry.value);
+    }
+  }
 
   /// **Returns the existing value for [key], or computes, stores, and returns a new one.**
   ///
@@ -124,6 +151,15 @@ abstract class ThreadSafeCache<K, V> {
   /// **Arguments:**
   /// - `key`: The key of the entry to remove.
   Future<void> remove(K key);
+
+  /// **Removes all entries with keys in [keys].**
+  ///
+  /// Missing keys are ignored.
+  Future<void> removeAll(Iterable<K> keys) async {
+    for (final key in keys) {
+      await remove(key);
+    }
+  }
 
   /// **Removes all entries that match [test].**
   ///

--- a/lib/src/interfaces/thread_safe_ttl_cache.dart
+++ b/lib/src/interfaces/thread_safe_ttl_cache.dart
@@ -19,6 +19,17 @@ abstract class ThreadSafeTTLCacheInterface<K, V> extends ThreadSafeCache<K, V> {
   @override
   Future<void> set(K key, V value, {Duration? ttl});
 
+  /// **Stores all key-value pairs from [entries].**
+  ///
+  /// - If [ttl] is omitted, the cache implementation's default TTL is used.
+  /// - If a key already exists, its value and expiry are updated.
+  @override
+  Future<void> setAll(Map<K, V> entries, {Duration? ttl}) async {
+    for (final entry in entries.entries) {
+      await set(entry.key, entry.value, ttl: ttl);
+    }
+  }
+
   /// **Returns the existing value for [key], or computes, stores, and returns a new one.**
   ///
   /// When a new value is stored, [ttl] overrides the implementation's default

--- a/test/interfaces/cache_get_or_compute_test.dart
+++ b/test/interfaces/cache_get_or_compute_test.dart
@@ -430,6 +430,21 @@ void main() {
       expect(cache.get('short'), isNull);
     });
 
+    test('SimpleTTLCacheInterface setAll forwards ttl override', () {
+      final SimpleTTLCacheInterface<String, String> cache = SimpleTTLCache(
+        ttl: const Duration(seconds: 30),
+        clock: clock,
+      );
+
+      cache.setAll({
+        'short-a': 'A',
+        'short-b': 'B',
+      }, ttl: const Duration(seconds: 5));
+      now = now.add(const Duration(seconds: 10));
+
+      expect(cache.getAll(['short-a', 'short-b']), isEmpty);
+    });
+
     test('SimpleTTLCacheInterface update forwards ttl override', () {
       final SimpleTTLCacheInterface<String, String> cache = SimpleTTLCache(
         ttl: const Duration(seconds: 30),
@@ -471,6 +486,21 @@ void main() {
         expect(await cache.get('short'), isNull);
       },
     );
+
+    test('ThreadSafeTTLCacheInterface setAll forwards ttl override', () async {
+      final ThreadSafeTTLCacheInterface<String, String> cache = TTLCache(
+        ttl: const Duration(seconds: 30),
+        clock: clock,
+      );
+
+      await cache.setAll({
+        'short-a': 'A',
+        'short-b': 'B',
+      }, ttl: const Duration(seconds: 5));
+      now = now.add(const Duration(seconds: 10));
+
+      expect(await cache.getAll(['short-a', 'short-b']), isEmpty);
+    });
 
     test('ThreadSafeTTLCacheInterface update forwards ttl override', () async {
       final ThreadSafeTTLCacheInterface<String, String> cache = TTLCache(
@@ -521,6 +551,16 @@ void main() {
       expect(cache.setTtls['missing'], equals(const Duration(seconds: 10)));
 
       expect(() => cache.update('absent', (value) => value), throwsStateError);
+    });
+
+    test('SimpleTTLCacheInterface default setAll forwards ttl override', () {
+      final cache = _DefaultSimpleTTLCache<String, int>();
+
+      cache.setAll({'a': 1, 'b': 2}, ttl: const Duration(seconds: 5));
+
+      expect(cache.getAll(['a', 'b']), equals({'a': 1, 'b': 2}));
+      expect(cache.setTtls['a'], equals(const Duration(seconds: 5)));
+      expect(cache.setTtls['b'], equals(const Duration(seconds: 5)));
     });
 
     test(
@@ -587,6 +627,19 @@ void main() {
           () => cache.update('absent', (value) => value),
           throwsStateError,
         );
+      },
+    );
+
+    test(
+      'ThreadSafeTTLCacheInterface default setAll forwards ttl override',
+      () async {
+        final cache = _DefaultThreadSafeTTLCache<String, int>();
+
+        await cache.setAll({'a': 1, 'b': 2}, ttl: const Duration(seconds: 5));
+
+        expect(await cache.getAll(['a', 'b']), equals({'a': 1, 'b': 2}));
+        expect(cache.setTtls['a'], equals(const Duration(seconds: 5)));
+        expect(cache.setTtls['b'], equals(const Duration(seconds: 5)));
       },
     );
 

--- a/test/interfaces/cache_state_contract_test.dart
+++ b/test/interfaces/cache_state_contract_test.dart
@@ -29,6 +29,11 @@ class _DefaultSimpleCache<K, V> extends SimpleCache<K, V> {
   }
 }
 
+class _NullAfterContainsSimpleCache<K, V> extends _DefaultSimpleCache<K, V> {
+  @override
+  bool containsKey(K key) => true;
+}
+
 class _DefaultThreadSafeCache<K, V> extends ThreadSafeCache<K, V> {
   final Map<K, V> _cache = {};
 
@@ -55,6 +60,12 @@ class _DefaultThreadSafeCache<K, V> extends ThreadSafeCache<K, V> {
   Future<void> clear() async {
     _cache.clear();
   }
+}
+
+class _NullAfterContainsThreadSafeCache<K, V>
+    extends _DefaultThreadSafeCache<K, V> {
+  @override
+  Future<bool> containsKey(K key) async => true;
 }
 
 void main() {
@@ -158,6 +169,15 @@ void main() {
       );
     });
 
+    test(
+      'getAll omits null returned after containsKey for non-nullable values',
+      () {
+        final cache = _NullAfterContainsSimpleCache<String, String>();
+
+        expect(cache.getAll(['expired']), isEmpty);
+      },
+    );
+
     test('setAll stores entries and removeAll removes matching keys', () {
       final cache = _DefaultSimpleCache<String, int>();
 
@@ -260,6 +280,15 @@ void main() {
         equals({'present': 'value', 'null': null}),
       );
     });
+
+    test(
+      'getAll omits null returned after containsKey for non-nullable values',
+      () async {
+        final cache = _NullAfterContainsThreadSafeCache<String, String>();
+
+        expect(await cache.getAll(['expired']), isEmpty);
+      },
+    );
 
     test('setAll stores entries and removeAll removes matching keys', () async {
       final cache = _DefaultThreadSafeCache<String, int>();

--- a/test/interfaces/cache_state_contract_test.dart
+++ b/test/interfaces/cache_state_contract_test.dart
@@ -146,6 +146,27 @@ void main() {
       expect(computes, equals(0));
     });
 
+    test('getAll returns present values including stored nulls', () {
+      final cache = _DefaultSimpleCache<String, String?>();
+
+      cache.set('present', 'value');
+      cache.set('null', null);
+
+      expect(
+        cache.getAll(['present', 'missing', 'null']),
+        equals({'present': 'value', 'null': null}),
+      );
+    });
+
+    test('setAll stores entries and removeAll removes matching keys', () {
+      final cache = _DefaultSimpleCache<String, int>();
+
+      cache.setAll({'a': 1, 'b': 2, 'c': 3});
+      cache.removeAll(['b', 'missing']);
+
+      expect(cache.getAll(['a', 'b', 'c']), equals({'a': 1, 'c': 3}));
+    });
+
     test('update changes existing values and supports ifAbsent', () {
       final cache = _DefaultSimpleCache<String, int>();
 
@@ -179,6 +200,18 @@ void main() {
         expect(cache.get('a'), equals('A'));
       },
     );
+
+    test('getAll applies get policy side effects for present keys', () {
+      final SimpleCache<String, String> cache =
+          SimpleEphemeralFIFOCache<String, String>(3);
+
+      cache.set('a', 'A');
+      cache.set('b', 'B');
+
+      expect(cache.getAll(['a', 'missing', 'b']), equals({'a': 'A', 'b': 'B'}));
+      expect(cache.containsKey('a'), isFalse);
+      expect(cache.containsKey('b'), isFalse);
+    });
   });
 
   group('ThreadSafeCache state contract', () {
@@ -215,6 +248,27 @@ void main() {
         expect(computes, equals(0));
       },
     );
+
+    test('getAll returns present values including stored nulls', () async {
+      final cache = _DefaultThreadSafeCache<String, String?>();
+
+      await cache.set('present', 'value');
+      await cache.set('null', null);
+
+      expect(
+        await cache.getAll(['present', 'missing', 'null']),
+        equals({'present': 'value', 'null': null}),
+      );
+    });
+
+    test('setAll stores entries and removeAll removes matching keys', () async {
+      final cache = _DefaultThreadSafeCache<String, int>();
+
+      await cache.setAll({'a': 1, 'b': 2, 'c': 3});
+      await cache.removeAll(['b', 'missing']);
+
+      expect(await cache.getAll(['a', 'b', 'c']), equals({'a': 1, 'c': 3}));
+    });
 
     test(
       'update changes existing values and supports async ifAbsent',
@@ -261,5 +315,20 @@ void main() {
         expect(await cache.containsKey('d'), isTrue);
       },
     );
+
+    test('getAll applies get policy side effects for present keys', () async {
+      final ThreadSafeCache<String, String> cache =
+          EphemeralFIFOCache<String, String>(3);
+
+      await cache.set('a', 'A');
+      await cache.set('b', 'B');
+
+      expect(
+        await cache.getAll(['a', 'missing', 'b']),
+        equals({'a': 'A', 'b': 'B'}),
+      );
+      expect(await cache.containsKey('a'), isFalse);
+      expect(await cache.containsKey('b'), isFalse);
+    });
   });
 }

--- a/test/monitorings/cache_alert_manager_test.dart
+++ b/test/monitorings/cache_alert_manager_test.dart
@@ -164,11 +164,20 @@ void main() {
     });
 
     test('Triggers alert when eviction rate exceeds threshold', () async {
+      alertManager.dispose();
+      final config = CacheAlertConfig(
+        notifyCallback: (alert) => receivedAlerts.add(alert),
+        evictionsPerMinuteThreshold: 1000,
+        alertCheckInterval: const Duration(seconds: 1),
+      );
+      alertManager = CacheAlertManager(metrics, config);
+
       // Run the monitor
       alertManager.monitor();
 
-      // Wait enough time for evictions to accumulate (2 seconds in this case)
-      await Future.delayed(const Duration(milliseconds: 2000));
+      // Record evictions after the monitor starts so they are inside the first
+      // one-second snapshot window even on slower SDK/runtime combinations.
+      await Future.delayed(const Duration(milliseconds: 100));
 
       // Record evictions in bulk to reduce the loop overhead
       for (int i = 0; i < 500; i++) {
@@ -176,7 +185,7 @@ void main() {
       }
 
       // Wait to ensure the monitoring catches the evictions
-      await Future.delayed(const Duration(milliseconds: 500));
+      await Future.delayed(const Duration(milliseconds: 1200));
 
       // Check if the alert for high eviction rate was triggered
       expect(


### PR DESCRIPTION
## 📝 PR Summary

Adds bulk cache operations for multi-key reads, writes, and invalidation across the cache interfaces.

### 🐛 Bugfix | 🚀 Feature | 📖 Documentation Update | 🚀 Release

- [ ] Bugfix
- [x] Feature
- [x] Documentation Update
- [ ] Release

### 🔧 Fix / Feature Details

- **Issue:** Cache users need a first-class way to read, warm, and invalidate multiple keys without manually repeating single-key operations.
- **Fix / Feature:** Added `getAll()`, `setAll()`, and `removeAll()` default APIs to simple and async-safe cache interfaces. Added TTL-aware `setAll(..., ttl:)` overloads for TTL cache abstractions so batches can share a per-entry TTL override.

### 📌 Related Issue

N/A

---

## 🔍 Testing

- [x] Unit tests passed
- [x] Manually verified expected behavior
- [x] Added regression tests (if applicable)

---

## 📖 Documentation Update (if applicable)

### 🔧 Documentation Changes

- [x] Updated README
- [ ] Updated API reference
- [ ] Added new guides/tutorials

### 🚀 Additional Notes

Bulk operation behavior is documented in the README API contracts section, including nullable value handling, cache policy side effects, and TTL `setAll()` overrides.

---

## 🚀 Release Checklist (if applicable)

### 📌 Release Checklist

- [ ] **Bump version in `pubspec.yaml`**
- [x] **Update `CHANGELOG.md` with release notes**
- [x] **Update `README.md` if necessary**
- [x] **Run `dart analyze` to ensure no issues**
- [x] **Run `dart test` to confirm all tests pass**
- [ ] **Ensure all dependencies are up to date**
- [ ] **Tag the release commit after merging**

<!-- Release Summary -->
<!--
### 📝 Release Summary
[//]: # "Provide a summary of this release (e.g., major changes, bug fixes, improvements)"

### 🔧 Release Changes

- [ ] Feature A
- [ ] Improvement B
- [ ] Bugfix C

### 🏷 Versioning

- **Current Version:** `X.Y.Z`
- **New Version:** `X.Y.Z+1`

### 🚀 Additional Notes

[//]: # "Any additional context, related issues, or references"
-->
